### PR TITLE
Http and https awareness

### DIFF
--- a/install/cli_install.php
+++ b/install/cli_install.php
@@ -244,13 +244,16 @@ function setup_db($data) {
 
 
 function write_config_files($options) {
+
+    $http_server = 'http://' . $_SERVER['SERVER_NAME'] . '/';
+    $https_server = 'https://' . $_SERVER['SERVER_NAME'] . '/';
+
 	$output  = '<?php' . "\n";
 	$output .= '// HTTP' . "\n";
-	$output .= 'define(\'HTTP_SERVER\', \'' . $options['http_server'] . '\');' . "\n";
-	$output .= 'define(\'HTTP_ADMIN\', \'' . $options['http_server'] . 'admin/\');' . "\n\n";
+	$output .= 'define(\'HTTP_SERVER\', \'' . $http_server . '\');' . "\n";
 
 	$output .= '// HTTPS' . "\n";
-	$output .= 'define(\'HTTPS_SERVER\', \'' . $options['http_server'] . '\');' . "\n";
+	$output .= 'define(\'HTTPS_SERVER\', \'' . $https_server . '\');' . "\n";
 
 	$output .= '// DIR' . "\n";
 	$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'catalog/\');' . "\n";
@@ -284,12 +287,12 @@ function write_config_files($options) {
 
 	$output  = '<?php' . "\n";
 	$output .= '// HTTP' . "\n";
-	$output .= 'define(\'HTTP_SERVER\', \'' . $options['http_server'] . 'admin/\');' . "\n";
-	$output .= 'define(\'HTTP_CATALOG\', \'' . $options['http_server'] . '\');' . "\n";
+	$output .= 'define(\'HTTP_SERVER\', \'' . $http_server . 'admin/\');' . "\n";
+	$output .= 'define(\'HTTP_CATALOG\', \'' . $http_server . '\');' . "\n";
 
 	$output .= '// HTTPS' . "\n";
-	$output .= 'define(\'HTTPS_SERVER\', \'' . $options['http_server'] . 'admin/\');' . "\n";
-	$output .= 'define(\'HTTPS_CATALOG\', \'' . $options['http_server'] . '\');' . "\n";
+	$output .= 'define(\'HTTPS_SERVER\', \'' . $https_server . 'admin/\');' . "\n";
+	$output .= 'define(\'HTTPS_CATALOG\', \'' . $https_server . '\');' . "\n";
 
 	$output .= '// DIR' . "\n";
 	$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'admin/\');' . "\n";

--- a/install/controller/install/step_3.php
+++ b/install/controller/install/step_3.php
@@ -10,12 +10,15 @@ class ControllerInstallStep3 extends Controller {
 
 			$this->model_install_install->database($this->request->post);
 
+            $http_server = 'http://' . $_SERVER['SERVER_NAME'] . '/';
+            $https_server = 'https://' . $_SERVER['SERVER_NAME'] . '/';
+
 			$output = '<?php' . "\n";
 			$output .= '// HTTP' . "\n";
-			$output .= 'define(\'HTTP_SERVER\', \'' . HTTP_OPENCART . '\');' . "\n\n";
+			$output .= 'define(\'HTTP_SERVER\', \'' . $http_server . '\');' . "\n\n";
 
 			$output .= '// HTTPS' . "\n";
-			$output .= 'define(\'HTTPS_SERVER\', \'' . HTTP_OPENCART . '\');' . "\n\n";
+			$output .= 'define(\'HTTPS_SERVER\', \'' . $https_server . '/\');' . "\n\n";
 
 			$output .= '// DIR' . "\n";
 			$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'catalog/\');' . "\n";
@@ -54,12 +57,12 @@ class ControllerInstallStep3 extends Controller {
 
 			$output = '<?php' . "\n";
 			$output .= '// HTTP' . "\n";
-			$output .= 'define(\'HTTP_SERVER\', \'' . HTTP_OPENCART . 'admin/\');' . "\n";
-			$output .= 'define(\'HTTP_CATALOG\', \'' . HTTP_OPENCART . '\');' . "\n\n";
+			$output .= 'define(\'HTTP_SERVER\', \'' . $http_server . '/admin/\');' . "\n";
+			$output .= 'define(\'HTTP_CATALOG\', \'' . $http_server . '\');' . "\n\n";
 
 			$output .= '// HTTPS' . "\n";
-			$output .= 'define(\'HTTPS_SERVER\', \'' . HTTP_OPENCART . 'admin/\');' . "\n";
-			$output .= 'define(\'HTTPS_CATALOG\', \'' . HTTP_OPENCART . '\');' . "\n\n";
+			$output .= 'define(\'HTTPS_SERVER\', \'' . $https_server . 'admin/\');' . "\n";
+			$output .= 'define(\'HTTPS_CATALOG\', \'' . $https_server . '/\');' . "\n\n";
 
 			$output .= '// DIR' . "\n";
 			$output .= 'define(\'DIR_APPLICATION\', \'' . DIR_OPENCART . 'admin/\');' . "\n";

--- a/system/library/url.php
+++ b/system/library/url.php
@@ -22,7 +22,7 @@ class Url {
 
     public function link($route, $args = '', $secure = false) {
         $code = $this->code ? $this->code . "/" : '';
-        if ($this->ssl && $secure) {
+        if($_SERVER['HTTPS'] == true) {
             $url = $this->ssl . $code . 'index.php?route=' . $route;
         } else {
             $url = $this->url . $code . 'index.php?route=' . $route;

--- a/system/startup.php
+++ b/system/startup.php
@@ -60,9 +60,7 @@ if (!isset($_SERVER['HTTP_HOST'])) {
 }
 
 // Check if SSL
-if ((isset($_SERVER['HTTPS']) && (($_SERVER['HTTPS'] == 'on') || ($_SERVER['HTTPS'] == '1'))) || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)) {
-    $_SERVER['HTTPS'] = true;
-} elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on') {
+if($_SERVER['REQUEST_SCHEME'] == 'https') {
     $_SERVER['HTTPS'] = true;
 } else {
     $_SERVER['HTTPS'] = false;


### PR DESCRIPTION
This pull request does the following: 

1) writes different values to the config.php file for HTTP_SERVER and HTTPS_SERVER

2) simplifies how  $_SERVER[‘HTTPS’] is set

3) Builds links based on the request method (if a page is requested via HTTP, it builds links using HTTP, if requested via HTTPS, we build HTTPS links).

To do: Add new setting to config.php to override override this (i.e. ‘FORCE_SSL’).

I think this is all a lot more sane than the method OC took.