### PR TITLE
add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+.DS_Store


### PR DESCRIPTION
the Mac OS finder creates .DS_Store files in any directory that is opened. This just adds that file to the gitignore file