### PR TITLE
Query Logging for MySQLi adapter

### DIFF
--- a/install/cli_install.php
+++ b/install/cli_install.php
@@ -279,8 +279,10 @@ function write_config_files($options) {
 	$output .= 'define(\'DB_PORT\', \'' . addslashes($options['db_port']) . '\');' . "\n\n";
 
     $output .= '// DEBUGGING' . "\n";
-    $output .= '// Use extreme caution enabling this on production systems!' . "\n";
-    $output .= 'define(\'DEBUG\', false);' . "\n";
+    $output .= '// Set to \'debug\' to enable query logging; use with extreme caution' . "\n";
+    $output .= '// This logs all queries to the directory specified in DIR_LOGS.' . "\n";
+    $output .= '// This directory should NOT be readable by the world!' . "\n";
+    $output .= 'define(\'MODE\', \'production\');' . "\n";
 
 	$file = fopen(DIR_OPENCART . 'config.php', 'w');
 
@@ -322,8 +324,10 @@ function write_config_files($options) {
 	$output .= 'define(\'DB_PORT\', \'' . addslashes($options['db_port']) . '\');' . "\n\n";
 
     $output .= '// DEBUGGING' . "\n";
-    $output .= '// Use extreme caution enabling this on production systems!' . "\n";
-    $output .= 'define(\'DEBUG\', false);' . "\n";
+    $output .= '// Set to \'debug\' to enable query logging; use with extreme caution' . "\n";
+    $output .= '// This logs all queries to the directory specified in DIR_LOGS.' . "\n";
+    $output .= '// This directory should NOT be readable by the world!' . "\n";
+    $output .= 'define(\'MODE\', \'production\');' . "\n";
 
 	$file = fopen(DIR_OPENCART . 'admin/config.php', 'w');
 

--- a/install/cli_install.php
+++ b/install/cli_install.php
@@ -276,8 +276,11 @@ function write_config_files($options) {
 	$output .= 'define(\'DB_PASSWORD\', \'' . addslashes($options['db_password']) . '\');' . "\n";
 	$output .= 'define(\'DB_DATABASE\', \'' . addslashes($options['db_database']) . '\');' . "\n";
 	$output .= 'define(\'DB_PREFIX\', \'' . addslashes($options['db_prefix']) . '\');' . "\n";
-	$output .= 'define(\'DB_PORT\', \'' . addslashes($options['db_port']) . '\');' . "\n";
-	$output .= '?>';
+	$output .= 'define(\'DB_PORT\', \'' . addslashes($options['db_port']) . '\');' . "\n\n";
+
+    $output .= '// DEBUGGING' . "\n";
+    $output .= '// Use extreme caution enabling this on production systems!' . "\n";
+    $output .= 'define(\'DEBUG\', false);' . "\n";
 
 	$file = fopen(DIR_OPENCART . 'config.php', 'w');
 
@@ -316,8 +319,11 @@ function write_config_files($options) {
 	$output .= 'define(\'DB_PASSWORD\', \'' . addslashes($options['db_password']) . '\');' . "\n";
 	$output .= 'define(\'DB_DATABASE\', \'' . addslashes($options['db_database']) . '\');' . "\n";
 	$output .= 'define(\'DB_PREFIX\', \'' . addslashes($options['db_prefix']) . '\');' . "\n";
-	$output .= 'define(\'DB_PORT\', \'' . addslashes($options['db_port']) . '\');' . "\n";
-	$output .= '?>';
+	$output .= 'define(\'DB_PORT\', \'' . addslashes($options['db_port']) . '\');' . "\n\n";
+
+    $output .= '// DEBUGGING' . "\n";
+    $output .= '// Use extreme caution enabling this on production systems!' . "\n";
+    $output .= 'define(\'DEBUG\', false);' . "\n";
 
 	$file = fopen(DIR_OPENCART . 'admin/config.php', 'w');
 

--- a/install/controller/install/step_3.php
+++ b/install/controller/install/step_3.php
@@ -43,7 +43,11 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'DB_PASSWORD\', \'' . addslashes(html_entity_decode($this->request->post['db_password'], ENT_QUOTES, 'UTF-8')) . '\');' . "\n";
 			$output .= 'define(\'DB_DATABASE\', \'' . addslashes($this->request->post['db_database']) . '\');' . "\n";
 			$output .= 'define(\'DB_PORT\', \'' . addslashes($this->request->post['db_port']) . '\');' . "\n";
-			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n";
+			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n\n";
+
+            $output .= '// DEBUGGING' . "\n";
+            $output .= '// Use extreme caution enabling this on production systems!' . "\n";
+            $output .= 'define(\'DEBUG\', false);' . "\n";
 
 			if (!file_exists(DIR_OPENCART . 'config.php')) {
 				touch(DIR_OPENCART . 'config.php');
@@ -88,7 +92,11 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'DB_PASSWORD\', \'' . addslashes(html_entity_decode($this->request->post['db_password'], ENT_QUOTES, 'UTF-8')) . '\');' . "\n";
 			$output .= 'define(\'DB_DATABASE\', \'' . addslashes($this->request->post['db_database']) . '\');' . "\n";
 			$output .= 'define(\'DB_PORT\', \'' . addslashes($this->request->post['db_port']) . '\');' . "\n";
-			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n";
+			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n\n";
+
+            $output .= '// DEBUGGING' . "\n";
+            $output .= '// Use extreme caution enabling this on production systems!' . "\n";
+            $output .= 'define(\'DEBUG\', false);' . "\n";
 
 			if (!file_exists(DIR_OPENCART . 'admin/config.php')) {
 				touch(DIR_OPENCART . 'admin/config.php');

--- a/install/controller/install/step_3.php
+++ b/install/controller/install/step_3.php
@@ -46,8 +46,10 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n\n";
 
             $output .= '// DEBUGGING' . "\n";
-            $output .= '// Use extreme caution enabling this on production systems!' . "\n";
-            $output .= 'define(\'DEBUG\', false);' . "\n";
+            $output .= '// Set to \'debug\' to enable query logging; use with extreme caution' . "\n";
+            $output .= '// This logs all queries to the directory specified in DIR_LOGS.' . "\n";
+            $output .= '// This directory should NOT be readable by the world!' . "\n";
+            $output .= 'define(\'MODE\', \'production\');' . "\n";
 
 			if (!file_exists(DIR_OPENCART . 'config.php')) {
 				touch(DIR_OPENCART . 'config.php');
@@ -95,8 +97,10 @@ class ControllerInstallStep3 extends Controller {
 			$output .= 'define(\'DB_PREFIX\', \'' . addslashes($this->request->post['db_prefix']) . '\');' . "\n\n";
 
             $output .= '// DEBUGGING' . "\n";
-            $output .= '// Use extreme caution enabling this on production systems!' . "\n";
-            $output .= 'define(\'DEBUG\', false);' . "\n";
+            $output .= '// Set to \'debug\' to enable query logging; use with extreme caution' . "\n";
+            $output .= '// This logs all queries to the directory specified in DIR_LOGS.' . "\n";
+            $output .= '// This directory should NOT be readable by the world!' . "\n";
+            $output .= 'define(\'MODE\', \'production\');' . "\n";
 
 			if (!file_exists(DIR_OPENCART . 'admin/config.php')) {
 				touch(DIR_OPENCART . 'admin/config.php');

--- a/system/library/db/mysqli.php
+++ b/system/library/db/mysqli.php
@@ -14,6 +14,16 @@ final class MySQLi {
 
         $this->connection->set_charset("utf8");
         $this->connection->query("SET SQL_MODE = ''");
+    
+       if(DEBUG === true) {
+           $this->connection->query("set global general_log_file = \"/tmp/mysql_query.log\"");
+           $this->connection->query("set global general_log = \"ON\"");
+       }
+       
+	   if(DEBUG === false) {
+           $this->connection->query("set global general_log = \"OFF\"");
+       }
+
     }
 
     public function query($sql) {

--- a/system/library/db/mysqli.php
+++ b/system/library/db/mysqli.php
@@ -14,20 +14,35 @@ final class MySQLi {
 
         $this->connection->set_charset("utf8");
         $this->connection->query("SET SQL_MODE = ''");
-    
-       if(DEBUG === true) {
-           $this->connection->query("set global general_log_file = \"/tmp/mysql_query.log\"");
-           $this->connection->query("set global general_log = \"ON\"");
-       }
-       
-	   if(DEBUG === false) {
-           $this->connection->query("set global general_log = \"OFF\"");
-       }
 
     }
 
     public function query($sql) {
-        $query = $this->connection->query($sql);
+
+        if(defined('MODE') && (MODE == 'debug')) {
+            $start_time = microtime(true);
+
+            $query = $this->connection->query($sql);
+
+            $msec = number_format(microtime(true) - $start_time, 4, '.', ',') . " msec";
+
+            $output = date("Y-m-d h:i:s"). " \t";
+            $output .= $msec . " \t";
+            $output .= $sql . " \n";
+
+            if (!file_exists(DIR_LOGS . 'mysql_queries.txt')) {
+                touch(DIR_LOGS . 'mysql_queries.txt');
+            }
+
+            $file = fopen(DIR_LOGS . 'mysql_queries.txt', 'a');
+
+            fwrite($file, $output);
+
+            fclose($file);
+
+        } else {
+            $query = $this->connection->query($sql);
+        }
 
         if (!$this->connection->errno) {
             if ($query instanceof \mysqli_result) {


### PR DESCRIPTION
Enables MySQL query logging if MODE is defined and set to ‘debug’

Logs all queries to the system log directory, in a tab separated file, with the following fields:

Date/Time
Execution Time (ms)
Query SQL