### PR TITLE
Update breadcrumbs.php

### DIFF
--- a/system/library/breadcrumbs.php
+++ b/system/library/breadcrumbs.php
@@ -23,6 +23,8 @@ class Breadcrumbs {
 	}
 	
 	public function render(){
+		// if in path only home link
+		if( count( $this->path ) == 1 ) return null;
 	
 		$html = '<ul class="breadcrumb">';
 		foreach ( $this->path as $part ) {
@@ -40,6 +42,8 @@ class Breadcrumbs {
 	}
 	
 	public function getPath(){
+		// if in path only home link
+		if( count( $this->path ) == 1 ) return null;
 		
 		return $this->path;
 		


### PR DESCRIPTION
If in controller do not use method push: render and getPath returns null and the header.tpl will not show breadcrumbs.
Using breadcrumbs->push in controller mean that the page is not the home page.