### PR TITLE
Fix for universal redirect error during installation

### DIFF
--- a/system/startup.php
+++ b/system/startup.php
@@ -47,7 +47,7 @@ if (!empty($_SERVER['REQUEST_SCHEME']) && $_SERVER['REQUEST_SCHEME'] == 'https')
 }
 
 // Universal Host redirect to correct hostname
-if ($_SERVER['HTTP_HOST'] != parse_url(HTTPS_SERVER)['host'] && $_SERVER['HTTP_HOST'] != parse_url(HTTP_SERVER)['host']) {
+if (defined('HTTP_HOST') && defined('HTTPS_HOST') && $_SERVER['HTTP_HOST'] != parse_url(HTTPS_SERVER)['host'] && $_SERVER['HTTP_HOST'] != parse_url(HTTP_SERVER)['host']) {
     header("Location: " . ($_SERVER['HTTPS'] ? HTTPS_SERVER : HTTP_SERVER) . ltrim('/', $_SERVER['REQUEST_URI']));
 }
 


### PR DESCRIPTION
Was throwing an error during installation, as the constants HTTP_SERVER
and HTTPS_SERVER hadn’t been defined yet.