### PR TITLE
fix for #122

### DIFF
--- a/install/controller/install/step_3.php
+++ b/install/controller/install/step_3.php
@@ -112,7 +112,16 @@ class ControllerInstallStep3 extends Controller {
 
             /* create .htaccess file */
 
-            if(strstr(strtolower($_SERVER['SERVER_SOFTWARE']), 'apache') && array_search('mod_rewrite', apache_get_modules()) && !file_exists(DIR_OPENCART . '.htaccess')) {
+            /* check if mod_rewrite is enabled - checking phpinfo rather than apache_get_modules for greater compatibility */
+
+            ob_start();
+            phpinfo();
+            $phpinfo = ob_get_contents();
+            ob_end_clean();
+
+            $rewrite = strpos($phpinfo, "mod_rewrite");
+
+            if(strstr(strtolower($_SERVER['SERVER_SOFTWARE']), 'apache') && $rewrite && !file_exists(DIR_OPENCART . '.htaccess')) {
 
                 $output = "# 1.To use URL Alias you need to be running apache with mod_rewrite enabled. \n\n";
 


### PR DESCRIPTION
We’re checking the output of phpinfo() rather than apache_get_modules()
to fix fatal error when PHP is installed as CGI rather than as module.

In this case, .htaccess file and seo_urls will only be enabled if the
server is Apache and mod_rewrite is found in the output of phpinfo()