### PR TITLE
Copona CLI

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -10,3 +10,8 @@ define('APPLICATION', 'admin');
 require_once(DIR_PUBLIC . '/system/startup.php');
 
 start(APPLICATION);
+
+// Output
+global $response;
+$response->setCompression($config->get('config_compression'));
+$response->output();

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,14 @@
   "license": "GPL-3.0+",
   "require": {
     "copona/core": "dev-master"
+  },
+  "autoload": {
+    "psr-4": {
+      "Copona\\System\\": "./system/",
+      "Copona\\System\\Library\\": "./system/library/",
+      "Copona\\System\\Engine\\": "./system/engine/",
+      "Extension\\": "./extensions/",
+      "Theme\\": "./themes/"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,30 +11,6 @@
   "homepage": "https://github.com/copona/copona",
   "license": "GPL-3.0+",
   "require": {
-    "cardinity/cardinity-sdk-php": "^1.0",
-    "braintree/braintree_php": "3.2.0",
-    "leafo/scssphp": "0.0.12",
-    "divido/divido-php": ">=1.1.1",
-    "klarna/kco_rest": "^2.2",
-    "php": ">=5.6.0",
-    "phpmailer/phpmailer": "^5.2",
-    "robmorgan/phinx": "^0.6.6",
-    "filp/whoops": "^2.1",
-    "hassankhan/config": "^0.10.0",
-    "vlucas/phpdotenv": "^2.4",
-    "illuminate/container": "^5.4",
-    "twig/twig": "~1.0",
-    "symfony/finder": "^3.3",
-    "illuminate/support": "^5.4"
-  },
-  "autoload": {
-    "psr-4": {
-      "Copona\\": "./",
-      "Copona\\System\\": "system/",
-      "Copona\\System\\Library\\": "system/library/",
-      "Copona\\System\\Engine\\": "system/engine/",
-      "Extension\\": "extensions/",
-      "Theme\\": "themes/"
-    }
+    "copona/core": "dev-master"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -96,12 +96,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/copona/core.git",
-                "reference": "e464a98ba1d0009c3df117e81bf209d0ae704678"
+                "reference": "128d98f72508ac22e0a92910fd9b2a0238c7f065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/copona/core/zipball/e464a98ba1d0009c3df117e81bf209d0ae704678",
-                "reference": "e464a98ba1d0009c3df117e81bf209d0ae704678",
+                "url": "https://api.github.com/repos/copona/core/zipball/128d98f72508ac22e0a92910fd9b2a0238c7f065",
+                "reference": "128d98f72508ac22e0a92910fd9b2a0238c7f065",
                 "shasum": ""
             },
             "require": {
@@ -128,12 +128,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Copona\\": "./src",
-                    "Copona\\System\\": "/system/",
-                    "Copona\\System\\Library\\": "/system/library/",
-                    "Copona\\System\\Engine\\": "/system/engine/",
-                    "Extension\\": "/extensions/",
-                    "Theme\\": "/themes/"
+                    "Copona\\": "./src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -149,7 +144,7 @@
                 "framework",
                 "opensource"
             ],
-            "time": "2017-07-11 01:05:41"
+            "time": "2017-07-11 01:17:36"
         },
         {
             "name": "divido/divido-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "261adc1a59cf5cc45e1044372fab40d2",
+    "content-hash": "f374f10070836d9221aa18d134f4c0bf",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -89,6 +89,67 @@
             "description": "Client library for Cardinity credit card processing API",
             "homepage": "http://cardinity.com",
             "time": "2016-12-29T09:57:23+00:00"
+        },
+        {
+            "name": "copona/core",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/copona/core.git",
+                "reference": "e464a98ba1d0009c3df117e81bf209d0ae704678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/copona/core/zipball/e464a98ba1d0009c3df117e81bf209d0ae704678",
+                "reference": "e464a98ba1d0009c3df117e81bf209d0ae704678",
+                "shasum": ""
+            },
+            "require": {
+                "braintree/braintree_php": "3.2.0",
+                "cardinity/cardinity-sdk-php": "^1.0",
+                "divido/divido-php": ">=1.1.1",
+                "filp/whoops": "^2.1",
+                "hassankhan/config": "^0.10.0",
+                "illuminate/container": "^5.4",
+                "illuminate/support": "^5.4",
+                "klarna/kco_rest": "^2.2",
+                "leafo/scssphp": "0.0.12",
+                "php": ">=5.6.0",
+                "phpmailer/phpmailer": "^5.2",
+                "robmorgan/phinx": "^0.8",
+                "symfony/console": "^3.0",
+                "symfony/finder": "^3.3",
+                "twig/twig": "~1.0",
+                "vlucas/phpdotenv": "^2.4"
+            },
+            "bin": [
+                "bin/copona"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Copona\\": "./src",
+                    "Copona\\System\\": "/system/",
+                    "Copona\\System\\Library\\": "/system/library/",
+                    "Copona\\System\\Engine\\": "/system/engine/",
+                    "Extension\\": "/extensions/",
+                    "Theme\\": "/themes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Copona Core",
+            "homepage": "https://github.com/copona/copona",
+            "keywords": [
+                "copona",
+                "core",
+                "ecommerce",
+                "framework",
+                "opensource"
+            ],
+            "time": "2017-07-11 01:05:41"
         },
         {
             "name": "divido/divido-php",
@@ -1032,16 +1093,16 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "v0.6.6",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "cc97b79f62c2180caba0be1d3744a335a296a678"
+                "reference": "7a19de5bebc59321edd9613bc2a667e7f96224ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/cc97b79f62c2180caba0be1d3744a335a296a678",
-                "reference": "cc97b79f62c2180caba0be1d3744a335a296a678",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/7a19de5bebc59321edd9613bc2a667e7f96224ec",
+                "reference": "7a19de5bebc59321edd9613bc2a667e7f96224ec",
                 "shasum": ""
             },
             "require": {
@@ -1094,20 +1155,20 @@
                 "migrations",
                 "phinx"
             ],
-            "time": "2017-01-23T08:53:20+00:00"
+            "time": "2017-06-05T13:30:19+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.3.2",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "35716d4904e0506a7a5a9bcf23f854aeb5719bca"
+                "reference": "a094618deb9a3fe1c3cf500a796e167d0495a274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/35716d4904e0506a7a5a9bcf23f854aeb5719bca",
-                "reference": "35716d4904e0506a7a5a9bcf23f854aeb5719bca",
+                "url": "https://api.github.com/repos/symfony/config/zipball/a094618deb9a3fe1c3cf500a796e167d0495a274",
+                "reference": "a094618deb9a3fe1c3cf500a796e167d0495a274",
                 "shasum": ""
             },
             "require": {
@@ -1115,10 +1176,12 @@
                 "symfony/filesystem": "~2.8|~3.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<3.3",
+                "symfony/finder": "<3.3"
             },
             "require-dev": {
                 "symfony/dependency-injection": "~3.3",
+                "symfony/finder": "~3.3",
                 "symfony/yaml": "~3.0"
             },
             "suggest": {
@@ -1154,20 +1217,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T18:07:20+00:00"
+            "time": "2017-06-16T12:40:34+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.2",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "70d2a29b2911cbdc91a7e268046c395278238b2e"
+                "reference": "a97e45d98c59510f085fa05225a1acb74dfe0546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/70d2a29b2911cbdc91a7e268046c395278238b2e",
-                "reference": "70d2a29b2911cbdc91a7e268046c395278238b2e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a97e45d98c59510f085fa05225a1acb74dfe0546",
+                "reference": "a97e45d98c59510f085fa05225a1acb74dfe0546",
                 "shasum": ""
             },
             "require": {
@@ -1223,20 +1286,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T19:24:58+00:00"
+            "time": "2017-07-03T13:19:36+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.2",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e9c50482841ef696e8fa1470d950a79c8921f45d"
+                "reference": "63b85a968486d95ff9542228dc2e4247f16f9743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e9c50482841ef696e8fa1470d950a79c8921f45d",
-                "reference": "e9c50482841ef696e8fa1470d950a79c8921f45d",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/63b85a968486d95ff9542228dc2e4247f16f9743",
+                "reference": "63b85a968486d95ff9542228dc2e4247f16f9743",
                 "shasum": ""
             },
             "require": {
@@ -1279,20 +1342,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T21:01:25+00:00"
+            "time": "2017-07-05T13:02:37+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.3.2",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c709670bf64721202ddbe4162846f250735842c0"
+                "reference": "311fa718389efbd8b627c272b9324a62437018cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c709670bf64721202ddbe4162846f250735842c0",
-                "reference": "c709670bf64721202ddbe4162846f250735842c0",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/311fa718389efbd8b627c272b9324a62437018cc",
+                "reference": "311fa718389efbd8b627c272b9324a62437018cc",
                 "shasum": ""
             },
             "require": {
@@ -1328,11 +1391,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-28T14:08:56+00:00"
+            "time": "2017-06-24T09:29:48+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.2",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -1504,16 +1567,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v2.8.22",
+            "version": "v2.8.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "9f323f762ad21bfb9df7c1afacbdd8addf0f8c50"
+                "reference": "6c019627f2a69b9ab2ac41fd53102148a55af564"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/9f323f762ad21bfb9df7c1afacbdd8addf0f8c50",
-                "reference": "9f323f762ad21bfb9df7c1afacbdd8addf0f8c50",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/6c019627f2a69b9ab2ac41fd53102148a55af564",
+                "reference": "6c019627f2a69b9ab2ac41fd53102148a55af564",
                 "shasum": ""
             },
             "require": {
@@ -1573,20 +1636,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T14:36:56+00:00"
+            "time": "2017-07-03T08:04:30+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.2",
+            "version": "v3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9752a30000a8ca9f4b34b5227d15d0101b96b063"
+                "reference": "1f93a8d19b8241617f5074a123e282575b821df8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9752a30000a8ca9f4b34b5227d15d0101b96b063",
-                "reference": "9752a30000a8ca9f4b34b5227d15d0101b96b063",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1f93a8d19b8241617f5074a123e282575b821df8",
+                "reference": "1f93a8d19b8241617f5074a123e282575b821df8",
                 "shasum": ""
             },
             "require": {
@@ -1628,20 +1691,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T22:05:06+00:00"
+            "time": "2017-06-15T12:58:50+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v1.34.3",
+            "version": "v1.34.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "451c6f4197e113e24c1c85bc3fc8c2d77adeff2e"
+                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/451c6f4197e113e24c1c85bc3fc8c2d77adeff2e",
-                "reference": "451c6f4197e113e24c1c85bc3fc8c2d77adeff2e",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f878bab48edb66ad9c6ed626bf817f60c6c096ee",
+                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee",
                 "shasum": ""
             },
             "require": {
@@ -1693,7 +1756,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-06-07T18:45:17+00:00"
+            "time": "2017-07-04T13:19:31+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -1749,11 +1812,11 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "copona/core": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {
-        "php": ">=5.6.0"
-    },
+    "platform": [],
     "platform-dev": []
 }

--- a/copona
+++ b/copona
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+
+foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+    if (file_exists($file)) {
+        require_once $file;
+        define('DIR_VENDOR', realpath(dirname($file)));
+        break;
+    }
+}
+
+\Copona\Helpers\Util::load_cp();
+
+use Symfony\Component\Console\Application;
+
+$application = new Application();
+$application->add(new \Copona\Cli\Commands\CacheClearCommand());
+$application->run();

--- a/index.php
+++ b/index.php
@@ -9,3 +9,8 @@ define('APPLICATION', 'catalog');
 require_once(DIR_PUBLIC . '/system/startup.php');
 
 start(APPLICATION);
+
+// Output
+global $response;
+$response->setCompression($config->get('config_compression'));
+$response->output();

--- a/install/index.php
+++ b/install/index.php
@@ -48,3 +48,8 @@ define('DIR_UPLOAD', DIR_STORAGE_PRIVATE . 'upload/');
 require_once(DIR_SYSTEM . 'startup.php');
 
 start(APPLICATION);
+
+// Output
+global $response;
+$response->setCompression($config->get('config_compression'));
+$response->output();

--- a/system/framework.php
+++ b/system/framework.php
@@ -33,6 +33,7 @@ $registry->singleton('request', Request::class);
 $response = new Response();
 $response->addHeader('Content-Type: text/html; charset=utf-8');
 $registry->set('response', $response);
+$GLOBALS['response'] = $response;
 
 // Database
 if ($config->get($application_config . '.db_autostart')) {
@@ -133,7 +134,3 @@ $controller->dispatch(
     new Action($config->get($application_config . '.action_router')),
     new Action($config->get($application_config . '.action_error'))
 );
-
-// Output
-$response->setCompression($config->get('config_compression'));
-$response->output();

--- a/system/library/language.php
+++ b/system/library/language.php
@@ -101,7 +101,6 @@ class Language extends Controller
         } elseif (is_file(DIR_LANGUAGE . $this->default . '/' . $filename . '.php')) {
             require(DIR_LANGUAGE . $this->default . '/' . $filename . '.php');
         } else {
-            //pr($filename);
             require(DIR_LANGUAGE . $this->default . '/' . $this->default . '.php');
         }
 
@@ -109,7 +108,6 @@ class Language extends Controller
         // TODO: arrayis merged every time, to override same keys from theme settings
         // must be optimized.
         $this->data = array_merge($this->data, $this->theme_language);
-        //pr($this->data );
         $data = array_merge($data, $this->data);
 
         return $this->data;

--- a/system/startup.php
+++ b/system/startup.php
@@ -66,6 +66,7 @@ if (file_exists(DIR_PUBLIC . '/.env')) {
 
 //Init Config
 $config = new ConfigManager(DIR_CONFIG);
+$GLOBALS['config'] = $config;
 
 // Helper
 require_once(DIR_SYSTEM . 'helper/debug.php');


### PR DESCRIPTION
I started the `copona CLI`

For now you have only the command `php copona cache:clear` (:

Another novelty is `copona/core` a package that will bring together the entire core of copona in the future, as well as system, migrations, among others. This isolates and makes it easier to update the copona core.
All composer dependencies are already inside it.
This package is in the packagist.