### PR TITLE
Delete two unnecessary queries

### DIFF
--- a/admin/model/localisation/geo_zone.php
+++ b/admin/model/localisation/geo_zone.php
@@ -8,8 +8,6 @@ class ModelLocalisationGeoZone extends Model {
 
         if (isset($data['zone_to_geo_zone'])) {
             foreach ($data['zone_to_geo_zone'] as $value) {
-                $this->db->query("DELETE FROM " . DB_PREFIX . "zone_to_geo_zone WHERE geo_zone_id = '" . (int)$geo_zone_id . "' AND country_id = '" . (int)$value['country_id'] . "' AND zone_id = '" . (int)$value['zone_id'] . "'");
-
                 $this->db->query("INSERT INTO " . DB_PREFIX . "zone_to_geo_zone SET country_id = '" . (int)$value['country_id'] . "', zone_id = '" . (int)$value['zone_id'] . "', geo_zone_id = '" . (int)$geo_zone_id . "', date_added = NOW()");
             }
         }
@@ -26,8 +24,6 @@ class ModelLocalisationGeoZone extends Model {
 
         if (isset($data['zone_to_geo_zone'])) {
             foreach ($data['zone_to_geo_zone'] as $value) {
-                $this->db->query("DELETE FROM " . DB_PREFIX . "zone_to_geo_zone WHERE geo_zone_id = '" . (int)$geo_zone_id . "' AND country_id = '" . (int)$value['country_id'] . "' AND zone_id = '" . (int)$value['zone_id'] . "'");
-
                 $this->db->query("INSERT INTO " . DB_PREFIX . "zone_to_geo_zone SET country_id = '" . (int)$value['country_id'] . "', zone_id = '" . (int)$value['zone_id'] . "', geo_zone_id = '" . (int)$geo_zone_id . "', date_added = NOW()");
             }
         }

--- a/admin/model/localisation/order_status.php
+++ b/admin/model/localisation/order_status.php
@@ -44,9 +44,7 @@ class ModelLocalisationOrderStatus extends Model {
         //prd($this->config->get('config_language_id'));
 
         if ($data) {
-            $sql = "SELECT * FROM " . DB_PREFIX . "order_status WHERE language_id = '" . (int)$this->config->get('config_language_id') . "'";
-
-            $sql .= " ORDER BY name";
+            $sql = "SELECT * FROM " . DB_PREFIX . "order_status WHERE language_id = '" . (int)$this->config->get('config_language_id') . " ORDER BY name";
 
             if (isset($data['order']) && ($data['order'] == 'DESC')) {
                 $sql .= " DESC";


### PR DESCRIPTION
The delete query in addGeoZone is unnecessary because the related record won't exist - the zone_id it's was just generated in the preceding query.

In editGeoZone  - there is already a DELETE query preceding the foreach loop which would have deleted anything that the more specific DELETE in the loop would have found.

Both unnecessary.