### PR TITLE
Fix install compatibility: PHP 8.3, Docker, flash cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ RUN echo display_errors = On >> /opt/docker/etc/php/php.ini
 RUN echo error_reporting = E_ALL >> /opt/docker/etc/php/php.ini
 RUN echo display_startup_errors = On >> /opt/docker/etc/php/php.ini
 RUN mkdir -p /var/lib/php/session && chmod 777 /var/lib/php/session
+RUN mkdir -p /app/storage/public/cache/image \
+    /app/storage/public/cache \
+    /app/storage/private/cache \
+    /app/storage/private/logs \
+    /app/storage/private/download \
+    /app/storage/private/upload \
+    /app/storage/private/modification \
+    && chmod -R 777 /app/storage
 
 # xdebug 3.x config (xdebug 2.x ini keys removed in xdebug 3)
 RUN echo "xdebug.mode = off" >> /opt/docker/etc/php/php.ini

--- a/catalog/controller/checkout/cart.php
+++ b/catalog/controller/checkout/cart.php
@@ -287,7 +287,6 @@ class ControllerCheckoutCart extends Controller {
             foreach ($product_options as $product_option) {
                 if ($product_option['required'] && empty($option[$product_option['product_option_id']])) {
                     $json['error']['option'][$product_option['product_option_id']] = sprintf($this->language->get('error_required'), $product_option['name']);
-                    $this->flash->error( sprintf($this->language->get('error_required'), $product_option['name']) ) ;
                     $json['flash'] = sprintf($this->language->get('error_required'), $product_option['name']);
                 }
             }

--- a/catalog/controller/product/product.php
+++ b/catalog/controller/product/product.php
@@ -614,7 +614,7 @@ class ControllerProductProduct extends Controller {
 
 
 
-            $data['flash'] = $this->flash->display('error', false);
+            $data['flash'] = '';
 
             $data['column_left'] = $this->load->controller('common/column_left');
             $data['column_right'] = $this->load->controller('common/column_right');

--- a/catalog/model/catalog/category.php
+++ b/catalog/model/catalog/category.php
@@ -36,7 +36,7 @@ class ModelCatalogCategory extends Model {
         $start_time = microtime(true);
 
         $cats = [];
-        foreach (explode(',', $this->paths[$parent_id]['childrens']) as $category_id) {
+        foreach (explode(',', $this->paths[$parent_id]['childrens'] ?? '') as $category_id) {
             if (!empty($this->paths[$category_id]['path'])) {
                 $cats[] = $this->paths[$category_id];
             }

--- a/catalog/model/catalog/product.php
+++ b/catalog/model/catalog/product.php
@@ -81,7 +81,7 @@ class ModelCatalogProduct extends Model {
               'height'              => $query->row['height'],
               'length_class_id'     => $query->row['length_class_id'],
               'subtract'            => $query->row['subtract'],
-              'rating'              => round($query->row['rating']),
+              'rating'              => round($query->row['rating'] ?? 0),
               'reviews'             => $query->row['reviews'] ? $query->row['reviews'] : 0,
               'minimum'             => $query->row['minimum'],
               'sort_order'          => $query->row['sort_order'],

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "php": ">=8.3",
-    "copona/core": "dev-php8",
+    "copona/core": "dev-fix-install-command",
     "twig/twig": "^3.26"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be3951f175d2f6bf8f5bf49c0f3b7ffe",
+    "content-hash": "780827c561a43426823c2ea08ecd3654",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -468,16 +468,16 @@
         },
         {
             "name": "copona/core",
-            "version": "dev-php8",
+            "version": "dev-fix-install-command",
             "source": {
                 "type": "git",
-                "url": "git@github.com:copona/core.git",
-                "reference": "f36f673c34166365b9536e5396e75bcb1c115cd0"
+                "url": "https://github.com/copona/core.git",
+                "reference": "4024adbfa794a6bd9e4aca469fed47b61415e349"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/copona/core/zipball/f36f673c34166365b9536e5396e75bcb1c115cd0",
-                "reference": "f36f673c34166365b9536e5396e75bcb1c115cd0",
+                "url": "https://api.github.com/repos/copona/core/zipball/4024adbfa794a6bd9e4aca469fed47b61415e349",
+                "reference": "4024adbfa794a6bd9e4aca469fed47b61415e349",
                 "shasum": ""
             },
             "require": {
@@ -493,8 +493,9 @@
                 "prhost/composer-vendor-merge": "^0.1",
                 "robmorgan/phinx": "^0.12 || ^0.16",
                 "symfony/console": "^6.0 || ^7.0",
+                "symfony/css-selector": "^6.0 || ^7.0",
                 "symfony/finder": "^6.0 || ^7.0",
-                "twig/twig": "^2.0 || ^3.0"
+                "twig/twig": "^3.26"
             },
             "bin": [
                 "bin/copona"
@@ -517,7 +518,11 @@
                 "framework",
                 "opensource"
             ],
-            "time": "2026-06-05T22:52:26+00:00"
+            "support": {
+                "source": "https://github.com/copona/core/tree/fix-install-command",
+                "issues": "https://github.com/copona/core/issues"
+            },
+            "time": "2026-06-05T23:41:49+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3480,20 +3485,20 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.1.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
-                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b75663ed96cf4756e28e3105476f220f92886cc4",
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -3525,7 +3530,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -3545,7 +3550,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -6023,6 +6028,6 @@
     "platform": {
         "php": ">=8.3"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
-version: '2.0'
 services:
   db:
-    env_file:
-      - .env
-    image: mysql:5.6
+    image: mariadb:12.3.2
     ports:
       - "3306:3306"
     environment:
@@ -14,8 +11,6 @@ services:
       - ./.mysql:/var/lib/mysql
 
   web:
-    env_file:
-      - .env
     build:
       context: .
     volumes:
@@ -25,8 +20,19 @@ services:
       - ~/.composer:/home/application/.composer
       - ~/.ssh:/home/application/.ssh
     ports:
-      - "80:80"
+      - "8080:80"
     depends_on:
       - db
     links:
       - "db:database"
+    environment:
+      DB_DRIVER: mysqli
+      DB_HOSTNAME: database
+      DB_DATABASE: copona
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      DB_PORT: 3306
+      DB_PREFIX: cp_
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin123
+      ADMIN_EMAIL: admin@example.com

--- a/system/constants.php
+++ b/system/constants.php
@@ -10,7 +10,10 @@ if (!defined('APPLICATION')) {
 
 //Get port
 $server_port = '';
-if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] != 80) && $_SERVER['SERVER_PORT'] != 443) {
+$_http_host = $_SERVER['HTTP_HOST'] ?? null;
+// HTTP_HOST already contains the port when a non-standard port is used (e.g. "localhost:8080").
+// Only append SERVER_PORT when HTTP_HOST doesn't include one, to avoid "host:port:port" duplication.
+if ($_http_host && !str_contains($_http_host, ':') && isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != 80 && $_SERVER['SERVER_PORT'] != 443) {
     $server_port = ':' . $_SERVER['SERVER_PORT'];
 }
 
@@ -19,7 +22,7 @@ if (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] != 80) && $_SERVE
 // SERVER_NAME ir more reliable, but depends on server config. We should be more flexible and define it from HTTP_HOST,
 // or crerate configurable variable.
 // define('DOMAIN_NAME', isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] . $server_port : null);
-define('DOMAIN_NAME', isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] . $server_port : null);
+define('DOMAIN_NAME', $_http_host ? $_http_host . $server_port : null);
 
 $parse_url = parse_url($_SERVER['SCRIPT_NAME']);
 define('BASE_URI', str_replace(['index.php', '//'], '', $parse_url['path']));

--- a/system/library/cart/affiliate.php
+++ b/system/library/cart/affiliate.php
@@ -1,6 +1,10 @@
 <?php
 namespace Cart;
 class Affiliate {
+    private $config;
+    private $db;
+    private $request;
+    private $session;
 	private $affiliate_id;
 	private $firstname;
 	private $lastname;

--- a/system/library/cart/currency.php
+++ b/system/library/cart/currency.php
@@ -3,6 +3,11 @@
 namespace Cart;
 
 class Currency {
+    private $config;
+    private $db;
+    private $language;
+    private $request;
+    private $session;
     public $currencies = [];
     private $code;
     private $log;

--- a/system/library/cart/customer.php
+++ b/system/library/cart/customer.php
@@ -1,6 +1,11 @@
 <?php
 namespace Cart;
 class Customer {
+    private $config;
+    private $db;
+    private $request;
+    private $session;
+    private $hook;
 	private $customer_id;
     private $password;
     private $salt;

--- a/system/library/cart/length.php
+++ b/system/library/cart/length.php
@@ -3,6 +3,8 @@
 namespace Cart;
 
 class Length {
+    private $db;
+    private $config;
     private $lengths = array();
 
     public function __construct($registry) {

--- a/system/library/cart/tax.php
+++ b/system/library/cart/tax.php
@@ -2,6 +2,11 @@
 namespace Cart;
 
 final class Tax {
+    private $config;
+    private $db;
+    private $session;
+    private $currency;
+    private $log;
     private $tax_rates = array();
 
     public function __construct($registry) {

--- a/system/library/cart/user.php
+++ b/system/library/cart/user.php
@@ -3,6 +3,9 @@
 namespace Cart;
 
 class User {
+    private $db;
+    private $request;
+    private $session;
     private $user_id;
     private $user_group_id;
     private $username;

--- a/system/library/cart/weight.php
+++ b/system/library/cart/weight.php
@@ -3,6 +3,8 @@
 namespace Cart;
 
 class Weight {
+    private $db;
+    private $config;
     private $weights = array();
 
     public function __construct($registry) {

--- a/system/library/db/mysqli.php
+++ b/system/library/db/mysqli.php
@@ -4,6 +4,7 @@ namespace DB;
 
 final class MySQLi {
     private $connection;
+    private $log;
 
     public function __construct($hostname, $username, $password, $database, $port = '3306') {
 

--- a/system/library/image.php
+++ b/system/library/image.php
@@ -81,7 +81,7 @@ class Image {
 
         $extension = strtolower($info['extension']);
 
-        if (is_resource($this->image)) {
+        if ($this->image instanceof \GdImage || is_resource($this->image)) {
             if ($extension == 'jpeg' || $extension == 'jpg') {
                 imagejpeg($this->image, $file, $quality);
             } elseif ($extension == 'png') {

--- a/system/library/seourl.php
+++ b/system/library/seourl.php
@@ -2,6 +2,8 @@
 
 class Seourl
 {
+    private $config;
+    private $db;
 
     public function __construct($registry)
     {

--- a/system/library/session/db.php
+++ b/system/library/session/db.php
@@ -11,6 +11,7 @@
 namespace Session;
 
 final class DB {
+    private $db;
     public $data = array();
     public $expire = array();
 


### PR DESCRIPTION
## Summary

- **PHP 8.3 compatibility**: Added explicit private property declarations to `Cart/*`, `DB\MySQLi`, `Session\DB`, and `Seourl` classes — fixes dynamic property deprecation errors. Updated `image.php` to use `instanceof \GdImage` (replaces deprecated `is_resource()`). Added null coalescing for `category.childrens` and `product.rating`.
- **Docker improvements**: Upgraded `mysql:5.6` → `mariadb:12.3.2`, removed `version` key (deprecated in Compose v2+), inlined environment variables, pre-create `storage/*` directories with correct permissions, exposed app on port `8080`.
- **Bug fix**: `system/constants.php` — prevented `host:port:port` duplication when `HTTP_HOST` already includes the port (e.g. `localhost:8080`).
- **Flash message cleanup**: Removed remaining `$this->flash->*` calls from checkout cart and product controllers (flash library was dropped in the php8-upgrade PR).
- **Dependency**: Pin `copona/core` to `dev-fix-install-command` (adds `--no-interaction` install mode, PHP 8.3 null fixes, Symfony 5+ return type fix).

## Test plan

- [ ] `docker-compose up -d` builds and starts without errors
- [ ] Access `http://localhost:8080/install` and complete installation with inline env defaults
- [ ] Browse catalog, add to cart, proceed to checkout — no PHP deprecation warnings
- [ ] Admin panel loads correctly
- [ ] `php vendor/bin/phinx migrate` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)