### PR TITLE
Fix fresh install: strip LOCK/UNLOCK TABLES from structure.sql

### DIFF
--- a/migrations/structure.sql
+++ b/migrations/structure.sql
@@ -450,8 +450,6 @@ CREATE TABLE `oc_address` (
   PRIMARY KEY (`address_id`),
   KEY `customer_id` (`customer_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_address` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_affiliate_login`;
@@ -466,8 +464,6 @@ CREATE TABLE `oc_affiliate_login` (
   KEY `email` (`email`),
   KEY `ip` (`ip`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_affiliate_login` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_attribute`;
@@ -477,7 +473,6 @@ CREATE TABLE `oc_attribute` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`attribute_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_attribute` WRITE;
 INSERT INTO `oc_attribute` VALUES
 (1,1,1),
 (2,1,2),
@@ -491,7 +486,6 @@ INSERT INTO `oc_attribute` VALUES
 (10,4,10),
 (11,4,11),
 (12,4,12);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_attribute_description`;
@@ -501,7 +495,6 @@ CREATE TABLE `oc_attribute_description` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`attribute_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_attribute_description` WRITE;
 INSERT INTO `oc_attribute_description` VALUES
 (1,1,'Screen Size'),
 (2,1,'Resolution'),
@@ -515,7 +508,6 @@ INSERT INTO `oc_attribute_description` VALUES
 (10,1,'Operating System'),
 (11,1,'Weight'),
 (12,1,'Connectivity');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_attribute_group`;
@@ -524,13 +516,11 @@ CREATE TABLE `oc_attribute_group` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`attribute_group_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_attribute_group` WRITE;
 INSERT INTO `oc_attribute_group` VALUES
 (1,1),
 (2,2),
 (3,3),
 (4,4);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_attribute_group_description`;
@@ -540,13 +530,11 @@ CREATE TABLE `oc_attribute_group_description` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`attribute_group_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_attribute_group_description` WRITE;
 INSERT INTO `oc_attribute_group_description` VALUES
 (1,1,'Display'),
 (2,1,'Performance'),
 (3,1,'Camera'),
 (4,1,'Battery & Connectivity');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_banner`;
@@ -557,12 +545,10 @@ CREATE TABLE `oc_banner` (
   PRIMARY KEY (`banner_id`),
   KEY `status` (`status`)
 ) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_banner` WRITE;
 INSERT INTO `oc_banner` VALUES
 (6,'HP Products',1),
 (7,'Home Page Slideshow',1),
 (8,'Manufacturers',1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_banner_image`;
@@ -579,7 +565,6 @@ CREATE TABLE `oc_banner_image` (
   KEY `banner_id` (`banner_id`),
   KEY `language_id` (`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=99 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_banner_image` WRITE;
 INSERT INTO `oc_banner_image` VALUES
 (79,7,1,'iPhone 6','index.php?route=product/product&amp;path=57&amp;product_id=49','catalog/demo/banners/iPhone6.jpg',0,''),
 (80,7,1,'MacBookAir','','catalog/demo/banners/MacBookAir.jpg',0,''),
@@ -595,7 +580,6 @@ INSERT INTO `oc_banner_image` VALUES
 (96,8,1,'Sony','','catalog/demo/manufacturer/sony.png',0,''),
 (97,8,1,'Starbucks','','catalog/demo/manufacturer/starbucks.png',0,''),
 (98,8,1,'Nintendo','','catalog/demo/manufacturer/nintendo.png',0,'');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_banner_image_description`;
@@ -609,8 +593,6 @@ CREATE TABLE `oc_banner_image_description` (
   `image` varchar(255) NOT NULL,
   PRIMARY KEY (`banner_image_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_banner_image_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_category`;
@@ -629,7 +611,6 @@ CREATE TABLE `oc_category` (
   KEY `parent_id` (`parent_id`),
   KEY `status` (`status`)
 ) ENGINE=InnoDB AUTO_INCREMENT=111 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_category` WRITE;
 INSERT INTO `oc_category` VALUES
 (100,NULL,0,1,'',1,1,1,'2026-06-06 11:39:09','2026-06-06 11:39:09'),
 (101,NULL,0,1,'',1,2,1,'2026-06-06 11:39:09','2026-06-06 11:39:09'),
@@ -642,7 +623,6 @@ INSERT INTO `oc_category` VALUES
 (108,NULL,107,0,'',1,1,1,'2026-06-06 11:39:09','2026-06-06 11:39:09'),
 (109,NULL,107,0,'',1,2,1,'2026-06-06 11:39:09','2026-06-06 11:39:09'),
 (110,NULL,0,1,'',1,7,1,'2026-06-06 11:39:09','2026-06-06 11:39:09');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_category_description`;
@@ -661,7 +641,6 @@ CREATE TABLE `oc_category_description` (
   FULLTEXT KEY `name_2` (`name`),
   FULLTEXT KEY `description` (`description`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_category_description` WRITE;
 INSERT INTO `oc_category_description` VALUES
 (100,1,'Smartphones','Discover the latest smartphones from Apple, Samsung, Google and more.','Smartphones','Discover the latest smartphones from Apple, Samsung, Google and more.','Smartphones',1,NULL),
 (101,1,'Laptops &amp; Computers','From ultrabooks to powerhouse workstations — find the perfect laptop.','Laptops &amp; Computers','From ultrabooks to powerhouse workstations — find the perfect laptop.','Laptops &amp; Computers',1,NULL),
@@ -674,7 +653,6 @@ INSERT INTO `oc_category_description` VALUES
 (108,1,'Consoles','PlayStation, Xbox and more — the latest gaming consoles.','Consoles','PlayStation, Xbox and more — the latest gaming consoles.','Consoles',1,NULL),
 (109,1,'Gaming Accessories','Mice, keyboards, headsets and more gaming peripherals.','Gaming Accessories','Mice, keyboards, headsets and more gaming peripherals.','Gaming Accessories',1,NULL),
 (110,1,'Smart Home','Smart speakers, displays and home automation devices.','Smart Home','Smart speakers, displays and home automation devices.','Smart Home',1,NULL);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_category_filter`;
@@ -683,8 +661,6 @@ CREATE TABLE `oc_category_filter` (
   `filter_id` int(11) NOT NULL,
   PRIMARY KEY (`category_id`,`filter_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_category_filter` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_category_path`;
@@ -695,7 +671,6 @@ CREATE TABLE `oc_category_path` (
   PRIMARY KEY (`category_id`,`path_id`),
   KEY `path_id` (`path_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_category_path` WRITE;
 INSERT INTO `oc_category_path` VALUES
 (100,100,0),
 (101,101,0),
@@ -712,7 +687,6 @@ INSERT INTO `oc_category_path` VALUES
 (109,107,0),
 (109,109,1),
 (110,110,0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_category_to_layout`;
@@ -722,8 +696,6 @@ CREATE TABLE `oc_category_to_layout` (
   `layout_id` int(11) NOT NULL,
   PRIMARY KEY (`category_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_category_to_layout` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_category_to_store`;
@@ -732,7 +704,6 @@ CREATE TABLE `oc_category_to_store` (
   `store_id` int(11) NOT NULL,
   PRIMARY KEY (`category_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_category_to_store` WRITE;
 INSERT INTO `oc_category_to_store` VALUES
 (100,0),
 (101,0),
@@ -745,7 +716,6 @@ INSERT INTO `oc_category_to_store` VALUES
 (108,0),
 (109,0),
 (110,0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_content_meta`;
@@ -757,12 +727,10 @@ CREATE TABLE `oc_content_meta` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `content_type` (`content_type`(100),`content_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-LOCK TABLES `oc_content_meta` WRITE;
 INSERT INTO `oc_content_meta` VALUES
 (1,'order',1,'{\"company_name\":\"\",\"address_1\":\"\",\"vat_num\":\"\",\"reg_num\":\"\",\"address_2\":\"\",\"postcode2\":\"\",\"customer_type\":\"\"}'),
 (2,'order',2,'{\"company_name\":\"\",\"address_1\":\"\",\"vat_num\":\"\",\"reg_num\":\"\",\"address_2\":\"\",\"postcode2\":\"\",\"customer_type\":\"\"}'),
 (3,'product',42,'[]');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_country`;
@@ -776,7 +744,6 @@ CREATE TABLE `oc_country` (
   `status` tinyint(1) NOT NULL DEFAULT 1,
   PRIMARY KEY (`country_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=258 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_country` WRITE;
 INSERT INTO `oc_country` VALUES
 (1,'Afghanistan','AF','AFG','',0,1),
 (2,'Albania','AL','ALB','',0,1),
@@ -1031,7 +998,6 @@ INSERT INTO `oc_country` VALUES
 (255,'Tristan da Cunha','TA','SHN','',0,1),
 (256,'Guernsey','GG','GGY','',0,1),
 (257,'Jersey','JE','JEY','',0,1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_coupon`;
@@ -1052,12 +1018,10 @@ CREATE TABLE `oc_coupon` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`coupon_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_coupon` WRITE;
 INSERT INTO `oc_coupon` VALUES
 (4,'-10% Discount','2222','P',10.0000,0,0,0.0000,'2014-01-01','2020-01-01',10,'10',0,'2009-01-27 13:55:03'),
 (5,'Free Shipping','3333','P',0.0000,0,1,100.0000,'2014-01-01','2014-02-01',10,'10',0,'2009-03-14 21:13:53'),
 (6,'-10.00 Discount','1111','F',10.0000,0,0,10.0000,'2014-01-01','2020-01-01',100000,'10000',0,'2009-03-14 21:15:18');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_coupon_category`;
@@ -1066,8 +1030,6 @@ CREATE TABLE `oc_coupon_category` (
   `category_id` int(11) NOT NULL,
   PRIMARY KEY (`coupon_id`,`category_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_coupon_category` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_coupon_history`;
@@ -1080,8 +1042,6 @@ CREATE TABLE `oc_coupon_history` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`coupon_history_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_coupon_history` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_coupon_product`;
@@ -1091,8 +1051,6 @@ CREATE TABLE `oc_coupon_product` (
   `product_id` int(11) NOT NULL,
   PRIMARY KEY (`coupon_product_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_coupon_product` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_currency`;
@@ -1108,12 +1066,10 @@ CREATE TABLE `oc_currency` (
   `date_modified` datetime NOT NULL,
   PRIMARY KEY (`currency_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_currency` WRITE;
 INSERT INTO `oc_currency` VALUES
 (1,'Pound Sterling','GBP','£','','2',0.61250001,1,'2014-09-25 14:40:00'),
 (2,'US Dollar','USD','$','','2',1.00000000,1,'2014-09-25 14:40:00'),
 (3,'Euro','EUR','','€','2',0.78460002,1,'2014-09-25 14:40:00');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_custom_field`;
@@ -1127,8 +1083,6 @@ CREATE TABLE `oc_custom_field` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`custom_field_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_custom_field` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_custom_field_customer_group`;
@@ -1138,8 +1092,6 @@ CREATE TABLE `oc_custom_field_customer_group` (
   `required` tinyint(1) NOT NULL,
   PRIMARY KEY (`custom_field_id`,`customer_group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_custom_field_customer_group` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_custom_field_description`;
@@ -1149,8 +1101,6 @@ CREATE TABLE `oc_custom_field_description` (
   `name` varchar(128) NOT NULL,
   PRIMARY KEY (`custom_field_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_custom_field_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_custom_field_value`;
@@ -1160,8 +1110,6 @@ CREATE TABLE `oc_custom_field_value` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`custom_field_value_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_custom_field_value` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_custom_field_value_description`;
@@ -1172,8 +1120,6 @@ CREATE TABLE `oc_custom_field_value_description` (
   `name` varchar(128) NOT NULL,
   PRIMARY KEY (`custom_field_value_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_custom_field_value_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_customer_group`;
@@ -1183,10 +1129,8 @@ CREATE TABLE `oc_customer_group` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`customer_group_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_customer_group` WRITE;
 INSERT INTO `oc_customer_group` VALUES
 (1,0,1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_customer_group_description`;
@@ -1197,10 +1141,8 @@ CREATE TABLE `oc_customer_group_description` (
   `description` text NOT NULL,
   PRIMARY KEY (`customer_group_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_customer_group_description` WRITE;
 INSERT INTO `oc_customer_group_description` VALUES
 (1,1,'Default','test');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_customer_history`;
@@ -1211,8 +1153,6 @@ CREATE TABLE `oc_customer_history` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`customer_history_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_customer_history` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_customer_ip`;
@@ -1224,8 +1164,6 @@ CREATE TABLE `oc_customer_ip` (
   PRIMARY KEY (`customer_ip_id`),
   KEY `ip` (`ip`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_customer_ip` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_customer_online`;
@@ -1237,8 +1175,6 @@ CREATE TABLE `oc_customer_online` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`ip`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_customer_online` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_customer_search`;
@@ -1256,8 +1192,6 @@ CREATE TABLE `oc_customer_search` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`customer_search_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_customer_search` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_download`;
@@ -1268,8 +1202,6 @@ CREATE TABLE `oc_download` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`download_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_download` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_download_description`;
@@ -1279,8 +1211,6 @@ CREATE TABLE `oc_download_description` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`download_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_download_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_event`;
@@ -1293,10 +1223,8 @@ CREATE TABLE `oc_event` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`event_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_event` WRITE;
 INSERT INTO `oc_event` VALUES
 (1,'voucher','catalog/model/checkout/order/addOrderHistory/after','extension/total/voucher/send',0,'0000-00-00 00:00:00');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_extension`;
@@ -1307,7 +1235,6 @@ CREATE TABLE `oc_extension` (
   PRIMARY KEY (`extension_id`),
   KEY `type` (`type`)
 ) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_extension` WRITE;
 INSERT INTO `oc_extension` VALUES
 (1,'payment','cod'),
 (2,'total','shipping'),
@@ -1338,7 +1265,6 @@ INSERT INTO `oc_extension` VALUES
 (27,'dashboard','customer'),
 (28,'dashboard','chart'),
 (29,'module','cr_translate_mate');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_filter`;
@@ -1348,8 +1274,6 @@ CREATE TABLE `oc_filter` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`filter_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_filter` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_filter_description`;
@@ -1360,8 +1284,6 @@ CREATE TABLE `oc_filter_description` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`filter_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_filter_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_filter_group`;
@@ -1370,8 +1292,6 @@ CREATE TABLE `oc_filter_group` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`filter_group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_filter_group` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_filter_group_description`;
@@ -1381,8 +1301,6 @@ CREATE TABLE `oc_filter_group_description` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`filter_group_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_filter_group_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_geo_zone`;
@@ -1394,11 +1312,9 @@ CREATE TABLE `oc_geo_zone` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`geo_zone_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_geo_zone` WRITE;
 INSERT INTO `oc_geo_zone` VALUES
 (3,'UK VAT Zone','UK VAT','2010-02-26 22:33:24','2009-01-06 23:26:25'),
 (4,'UK Shipping','UK Shipping Zones','2010-12-15 15:18:13','2009-06-23 01:14:53');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_information`;
@@ -1411,13 +1327,11 @@ CREATE TABLE `oc_information` (
   `status` tinyint(1) NOT NULL DEFAULT 1,
   PRIMARY KEY (`information_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_information` WRITE;
 INSERT INTO `oc_information` VALUES
 (3,NULL,1,0,3,1),
 (4,NULL,1,0,1,1),
 (5,NULL,1,0,4,1),
 (6,NULL,1,0,2,1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_information_description`;
@@ -1432,13 +1346,11 @@ CREATE TABLE `oc_information_description` (
   `external_link` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`information_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_information_description` WRITE;
 INSERT INTO `oc_information_description` VALUES
 (3,1,'Privacy Policy','&lt;p&gt;\r\n	Privacy Policy&lt;/p&gt;\r\n','Privacy Policy','','',NULL),
 (4,1,'About Us','&lt;p&gt;\r\n	About Us&lt;/p&gt;\r\n','About Us','','',NULL),
 (5,1,'Terms &amp; Conditions','&lt;p&gt;\r\n	Terms &amp;amp; Conditions&lt;/p&gt;\r\n','Terms &amp; Conditions','','',NULL),
 (6,1,'Delivery Information','&lt;p&gt;\r\n	Delivery Information&lt;/p&gt;\r\n','Delivery Information','','',NULL);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_information_image`;
@@ -1450,8 +1362,6 @@ CREATE TABLE `oc_information_image` (
   PRIMARY KEY (`information_image_id`),
   KEY `information_id` (`information_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_information_image` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_information_to_layout`;
@@ -1461,8 +1371,6 @@ CREATE TABLE `oc_information_to_layout` (
   `layout_id` int(11) NOT NULL,
   PRIMARY KEY (`information_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_information_to_layout` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_information_to_store`;
@@ -1471,13 +1379,11 @@ CREATE TABLE `oc_information_to_store` (
   `store_id` int(11) NOT NULL,
   PRIMARY KEY (`information_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_information_to_store` WRITE;
 INSERT INTO `oc_information_to_store` VALUES
 (3,0),
 (4,0),
 (5,0),
 (6,0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_language`;
@@ -1494,10 +1400,8 @@ CREATE TABLE `oc_language` (
   KEY `name` (`name`),
   KEY `code` (`code`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_language` WRITE;
 INSERT INTO `oc_language` VALUES
 (1,'English','en','en-gb,en','en-gb.png','en-gb',1,1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_layout`;
@@ -1506,7 +1410,6 @@ CREATE TABLE `oc_layout` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`layout_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_layout` WRITE;
 INSERT INTO `oc_layout` VALUES
 (1,'Home'),
 (2,'Product'),
@@ -1521,7 +1424,6 @@ INSERT INTO `oc_layout` VALUES
 (11,'Information'),
 (12,'Compare'),
 (13,'Search');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_layout_module`;
@@ -1534,7 +1436,6 @@ CREATE TABLE `oc_layout_module` (
   PRIMARY KEY (`layout_module_id`),
   KEY `layout_id` (`layout_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=74 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_layout_module` WRITE;
 INSERT INTO `oc_layout_module` VALUES
 (2,4,'0','content_top',0),
 (3,4,'0','content_top',1),
@@ -1546,7 +1447,6 @@ INSERT INTO `oc_layout_module` VALUES
 (69,10,'affiliate','column_right',1),
 (72,3,'category','column_left',1),
 (73,3,'banner.30','column_left',2);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_layout_route`;
@@ -1557,7 +1457,6 @@ CREATE TABLE `oc_layout_route` (
   `route` varchar(64) NOT NULL,
   PRIMARY KEY (`layout_route_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=54 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_layout_route` WRITE;
 INSERT INTO `oc_layout_route` VALUES
 (17,10,0,'affiliate/%'),
 (20,2,0,'product/product'),
@@ -1572,7 +1471,6 @@ INSERT INTO `oc_layout_route` VALUES
 (45,5,0,'product/manufacturer'),
 (52,12,0,'product/compare'),
 (53,13,0,'product/search');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_length_class`;
@@ -1581,12 +1479,10 @@ CREATE TABLE `oc_length_class` (
   `value` decimal(15,8) NOT NULL,
   PRIMARY KEY (`length_class_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_length_class` WRITE;
 INSERT INTO `oc_length_class` VALUES
 (1,1.00000000),
 (2,10.00000000),
 (3,0.39370000);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_length_class_description`;
@@ -1597,12 +1493,10 @@ CREATE TABLE `oc_length_class_description` (
   `unit` varchar(4) NOT NULL,
   PRIMARY KEY (`length_class_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_length_class_description` WRITE;
 INSERT INTO `oc_length_class_description` VALUES
 (1,1,'Centimeter','cm'),
 (2,1,'Millimeter','mm'),
 (3,1,'Inch','in');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_location`;
@@ -1619,8 +1513,6 @@ CREATE TABLE `oc_location` (
   PRIMARY KEY (`location_id`),
   KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_location` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_manufacturer`;
@@ -1633,7 +1525,6 @@ CREATE TABLE `oc_manufacturer` (
   `external_link` text DEFAULT NULL,
   PRIMARY KEY (`manufacturer_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_manufacturer` WRITE;
 INSERT INTO `oc_manufacturer` VALUES
 (1,'Apple',NULL,1,'2026-06-06 11:39:08',NULL),
 (2,'Samsung',NULL,2,'2026-06-06 11:39:08',NULL),
@@ -1642,7 +1533,6 @@ INSERT INTO `oc_manufacturer` VALUES
 (5,'Sony',NULL,5,'2026-06-06 11:39:08',NULL),
 (6,'Microsoft',NULL,6,'2026-06-06 11:39:08',NULL),
 (7,'Logitech',NULL,7,'2026-06-06 11:39:08',NULL);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_manufacturer_to_store`;
@@ -1651,7 +1541,6 @@ CREATE TABLE `oc_manufacturer_to_store` (
   `store_id` int(11) NOT NULL,
   PRIMARY KEY (`manufacturer_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_manufacturer_to_store` WRITE;
 INSERT INTO `oc_manufacturer_to_store` VALUES
 (1,0),
 (2,0),
@@ -1660,7 +1549,6 @@ INSERT INTO `oc_manufacturer_to_store` VALUES
 (5,0),
 (6,0),
 (7,0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_menu`;
@@ -1673,8 +1561,6 @@ CREATE TABLE `oc_menu` (
   `status` tinyint(1) NOT NULL,
   PRIMARY KEY (`menu_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_menu` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_menu_description`;
@@ -1684,8 +1570,6 @@ CREATE TABLE `oc_menu_description` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`menu_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_menu_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_menu_module`;
@@ -1697,8 +1581,6 @@ CREATE TABLE `oc_menu_module` (
   PRIMARY KEY (`menu_module_id`),
   KEY `menu_id` (`menu_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_menu_module` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_migrations`;
@@ -1710,7 +1592,6 @@ CREATE TABLE `oc_migrations` (
   `breakpoint` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_migrations` WRITE;
 INSERT INTO `oc_migrations` VALUES
 (20170201230314,'AddTopToInformationTable','2026-06-06 14:37:25','2026-06-06 14:37:25',0),
 (20170201231023,'CreateTableImagesForInformationPages','2026-06-06 14:37:25','2026-06-06 14:37:25',0),
@@ -1741,7 +1622,6 @@ INSERT INTO `oc_migrations` VALUES
 (20191114145807,'ImageUrlForImages','2026-06-06 14:37:26','2026-06-06 14:37:26',0),
 (20200330074111,'IndexesForCartTable','2026-06-06 14:38:23','2026-06-06 14:38:23',0),
 (20260606143409,'SeedModernDemoProducts','2026-06-06 14:39:08','2026-06-06 14:39:09',0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_modification`;
@@ -1757,8 +1637,6 @@ CREATE TABLE `oc_modification` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`modification_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_modification` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_module`;
@@ -1769,14 +1647,12 @@ CREATE TABLE `oc_module` (
   `setting` text NOT NULL,
   PRIMARY KEY (`module_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=32 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_module` WRITE;
 INSERT INTO `oc_module` VALUES
 (27,'Home Page','slideshow','{\"name\":\"Home Page\",\"banner_id\":\"7\",\"width\":\"1140\",\"height\":\"380\",\"status\":\"1\"}'),
 (28,'Home Page','featured','{\"name\":\"Home Page\",\"product\":[\"43\",\"40\",\"42\",\"30\"],\"limit\":\"4\",\"width\":\"200\",\"height\":\"200\",\"status\":\"1\"}'),
 (29,'Home Page','carousel','{\"name\":\"Home Page\",\"banner_id\":\"8\",\"width\":\"130\",\"height\":\"100\",\"status\":\"1\"}'),
 (30,'Category','banner','{\"name\":\"Category\",\"banner_id\":\"6\",\"width\":\"182\",\"height\":\"182\",\"status\":\"1\"}'),
 (31,'Banner 1','banner','{\"name\":\"Banner 1\",\"banner_id\":\"6\",\"width\":\"182\",\"height\":\"182\",\"status\":\"1\"}');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_option`;
@@ -1786,7 +1662,6 @@ CREATE TABLE `oc_option` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`option_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_option` WRITE;
 INSERT INTO `oc_option` VALUES
 (1,'radio',1),
 (2,'checkbox',2),
@@ -1799,7 +1674,6 @@ INSERT INTO `oc_option` VALUES
 (10,'datetime',9),
 (11,'select',10),
 (12,'date',11);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_option_description`;
@@ -1810,7 +1684,6 @@ CREATE TABLE `oc_option_description` (
   `display` varchar(256) DEFAULT NULL,
   PRIMARY KEY (`option_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_option_description` WRITE;
 INSERT INTO `oc_option_description` VALUES
 (1,1,'Radio',''),
 (2,1,'Checkbox',''),
@@ -1823,7 +1696,6 @@ INSERT INTO `oc_option_description` VALUES
 (10,1,'Date &amp; Time',''),
 (11,1,'Size',''),
 (12,1,'Delivery Date','');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_option_value`;
@@ -1834,7 +1706,6 @@ CREATE TABLE `oc_option_value` (
   `sort_order` int(3) NOT NULL,
   PRIMARY KEY (`option_value_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=62 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_option_value` WRITE;
 INSERT INTO `oc_option_value` VALUES
 (10,5,'',1),
 (11,5,'',2),
@@ -1858,7 +1729,6 @@ INSERT INTO `oc_option_value` VALUES
 (56,1,'',7),
 (60,1,'',1),
 (61,1,'',2);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_option_value_description`;
@@ -1869,7 +1739,6 @@ CREATE TABLE `oc_option_value_description` (
   `name` varchar(128) NOT NULL,
   PRIMARY KEY (`option_value_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_option_value_description` WRITE;
 INSERT INTO `oc_option_value_description` VALUES
 (10,1,5,'128 GB'),
 (11,1,5,'256 GB'),
@@ -1893,7 +1762,6 @@ INSERT INTO `oc_option_value_description` VALUES
 (56,1,1,'Platinum Silver'),
 (60,1,1,'42mm'),
 (61,1,1,'46mm');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_order_status`;
@@ -1905,7 +1773,6 @@ CREATE TABLE `oc_order_status` (
   `send_invoice` tinyint(4) NOT NULL DEFAULT 0,
   PRIMARY KEY (`order_status_id`,`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_order_status` WRITE;
 INSERT INTO `oc_order_status` VALUES
 (1,1,'Pending','',0),
 (2,1,'Processing','',0),
@@ -1921,7 +1788,6 @@ INSERT INTO `oc_order_status` VALUES
 (14,1,'Expired','',0),
 (15,1,'Processed','',0),
 (16,1,'Voided','',0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product`;
@@ -1969,7 +1835,6 @@ CREATE TABLE `oc_product` (
   KEY `model` (`model`),
   FULLTEXT KEY `model_2` (`model`)
 ) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product` WRITE;
 INSERT INTO `oc_product` VALUES
 (1,'APPLE-IP16PRO','APPLE-IP16PRO','','','','','','',100,7,'','https://placehold.co/800x600/1d1d1f/f5f5f7?text=iPhone+16+Pro',1,1,999.0000,0,9,'2026-06-06',0.20000000,1,0.00000000,0.00000000,0.00000000,1,1,1,1,1,17,'2026-06-06 11:39:09','2026-06-06','','',999.0000),
 (2,'SAM-GS25U','SAM-GS25U','','','','','','',100,7,'','https://placehold.co/800x600/1a1a2e/e2e8f0?text=Galaxy+S25+Ultra',2,1,1299.0000,0,9,'2026-06-06',0.20000000,1,0.00000000,0.00000000,0.00000000,1,1,1,2,1,2,'2026-06-06 11:39:09','2026-06-06','','',1299.0000),
@@ -1986,7 +1851,6 @@ INSERT INTO `oc_product` VALUES
 (13,'MS-XBXSX','MS-XBXSX','','','','','','',100,7,'','https://placehold.co/800x600/107C10/ffffff?text=Xbox+Series+X',6,1,499.0000,0,9,'2026-06-06',0.20000000,1,0.00000000,0.00000000,0.00000000,1,1,1,2,1,0,'2026-06-06 11:39:09','2026-06-06','','',499.0000),
 (14,'LOGI-MXM3S','LOGI-MXM3S','','','','','','',100,7,'','https://placehold.co/800x600/0f172a/e2e8f0?text=MX+Master+3S',7,1,99.0000,0,9,'2026-06-06',0.20000000,1,0.00000000,0.00000000,0.00000000,1,1,1,1,1,0,'2026-06-06 11:39:09','2026-06-06','','',99.0000),
 (15,'APPLE-HPM','APPLE-HPM','','','','','','',100,7,'','https://placehold.co/800x600/f5f5f7/1d1d1f?text=HomePod+mini',1,1,99.0000,0,9,'2026-06-06',0.20000000,1,0.00000000,0.00000000,0.00000000,1,1,1,1,1,1,'2026-06-06 11:39:09','2026-06-06','','',99.0000);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_attribute`;
@@ -1997,7 +1861,6 @@ CREATE TABLE `oc_product_attribute` (
   `text` text NOT NULL,
   PRIMARY KEY (`product_id`,`attribute_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_attribute` WRITE;
 INSERT INTO `oc_product_attribute` VALUES
 (1,1,1,'6.3 inches'),
 (1,2,1,'2622 × 1206 pixels, 460 ppi'),
@@ -2119,7 +1982,6 @@ INSERT INTO `oc_product_attribute` VALUES
 (15,10,1,'audioOS / HomePod Software'),
 (15,11,1,'345 g'),
 (15,12,1,'Wi-Fi 6, Bluetooth 5.0, Thread, Ultra Wideband');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_description`;
@@ -2141,7 +2003,6 @@ CREATE TABLE `oc_product_description` (
   FULLTEXT KEY `name_2` (`name`),
   FULLTEXT KEY `description` (`description`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_description` WRITE;
 INSERT INTO `oc_product_description` VALUES
 (1,1,'iPhone 16 Pro','The most powerful iPhone ever. Featuring the A18 Pro chip with a 6-core GPU, the all-new 48 MP Fusion camera, and a stunning 6.3-inch Super Retina XDR display with ProMotion. Built from aerospace-grade titanium.','','iphone,apple,smartphone,5g,pro,titanium','iPhone 16 Pro','The most powerful iPhone ever. Featuring the A18 Pro chip with a 6-core GPU, the all-new 48 MP Fusion camera, and a stunning 6.3-inch Super Retina XDR display w','iphone,apple,smartphone,5g,pro,titanium','A18 Pro · 48 MP · 6.3\"',1,''),
 (2,1,'Samsung Galaxy S25 Ultra','The ultimate Android flagship. The Galaxy S25 Ultra is powered by Snapdragon 8 Elite, featuring a 200 MP pro-grade camera, an integrated S Pen, and a massive 6.9-inch Dynamic AMOLED 2X display at 120 Hz.','','samsung,galaxy,smartphone,android,s-pen,ultra','Samsung Galaxy S25 Ultra','The ultimate Android flagship. The Galaxy S25 Ultra is powered by Snapdragon 8 Elite, featuring a 200 MP pro-grade camera, an integrated S Pen, and a massive 6.','samsung,galaxy,smartphone,android,s-pen,ultra','Snapdragon 8 Elite · 200 MP · 6.9\"',1,''),
@@ -2158,7 +2019,6 @@ INSERT INTO `oc_product_description` VALUES
 (13,1,'Xbox Series X','The most powerful Xbox ever. Xbox Series X delivers 12 teraflops of raw GPU performance, 4K gaming at up to 120 fps, 1 TB Custom NVMe SSD, and Quick Resume — jump back into multiple games exactly where you left off.','','microsoft,xbox,series-x,console,gaming,4k','Xbox Series X','The most powerful Xbox ever. Xbox Series X delivers 12 teraflops of raw GPU performance, 4K gaming at up to 120 fps, 1 TB Custom NVMe SSD, and Quick Resume — ','microsoft,xbox,series-x,console,gaming,4k','12 TFLOPS · 4K 120fps · Quick Resume',1,''),
 (14,1,'Logitech MX Master 3S','The ultimate mouse for creators and power users. MX Master 3S features an ultra-fast MagSpeed electromagnetic scroll wheel, whisper-quiet clicks, 8000 DPI precision on any surface including glass, and connects to up to 3 devices via Bolt USB or Bluetooth.','','logitech,mouse,mx-master,productivity,wireless,ergonomic','Logitech MX Master 3S','The ultimate mouse for creators and power users. MX Master 3S features an ultra-fast MagSpeed electromagnetic scroll wheel, whisper-quiet clicks, 8000 DPI preci','logitech,mouse,mx-master,productivity,wireless,ergonomic','8K DPI · MagSpeed scroll · Multi-device',1,''),
 (15,1,'Apple HomePod mini','Surprisingly powerful sound in a compact design. HomePod mini delivers full 360° audio with computational audio, acts as a smart home hub for HomeKit and Matter accessories, supports Thread networking, and integrates seamlessly with all your Apple devices.','','apple,homepod,smart-speaker,smart-home,homekit,siri','Apple HomePod mini','Surprisingly powerful sound in a compact design. HomePod mini delivers full 360° audio with computational audio, acts as a smart home hub for HomeKit and Matte','apple,homepod,smart-speaker,smart-home,homekit,siri','360° audio · Smart home hub · Thread',1,'');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_discount`;
@@ -2178,8 +2038,6 @@ CREATE TABLE `oc_product_discount` (
   KEY `date_start` (`date_start`),
   KEY `date_end` (`date_end`)
 ) ENGINE=InnoDB AUTO_INCREMENT=453 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_discount` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_filter`;
@@ -2188,8 +2046,6 @@ CREATE TABLE `oc_product_filter` (
   `filter_id` int(11) NOT NULL,
   PRIMARY KEY (`product_id`,`filter_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_filter` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_image`;
@@ -2202,8 +2058,6 @@ CREATE TABLE `oc_product_image` (
   PRIMARY KEY (`product_image_id`),
   KEY `product_id` (`product_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2363 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_image` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_image_description`;
@@ -2215,14 +2069,12 @@ CREATE TABLE `oc_product_image_description` (
   `product_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_image_description` WRITE;
 INSERT INTO `oc_product_image_description` VALUES
 (2,2358,'1','',42),
 (3,2359,'1','',42),
 (4,2360,'1','',42),
 (5,2361,'1','',42),
 (6,2362,'1','',42);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_option`;
@@ -2234,7 +2086,6 @@ CREATE TABLE `oc_product_option` (
   `required` tinyint(1) NOT NULL,
   PRIMARY KEY (`product_option_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=249 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_option` WRITE;
 INSERT INTO `oc_product_option` VALUES
 (227,1,5,'',1),
 (228,1,1,'',1),
@@ -2258,7 +2109,6 @@ INSERT INTO `oc_product_option` VALUES
 (246,12,5,'',1),
 (247,14,1,'',1),
 (248,15,1,'',1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_option_value`;
@@ -2280,7 +2130,6 @@ CREATE TABLE `oc_product_option_value` (
   `description` varchar(254) NOT NULL DEFAULT '',
   PRIMARY KEY (`product_option_value_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=77 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_option_value` WRITE;
 INSERT INTO `oc_product_option_value` VALUES
 (17,227,1,5,11,50,1,0.0000,'+',0,'+',0.00000000,'+',NULL,''),
 (18,227,1,5,12,30,1,100.0000,'+',0,'+',0.00000000,'+',NULL,''),
@@ -2342,7 +2191,6 @@ INSERT INTO `oc_product_option_value` VALUES
 (74,248,15,1,54,20,1,0.0000,'+',0,'+',0.00000000,'+',NULL,''),
 (75,248,15,1,50,20,1,0.0000,'+',0,'+',0.00000000,'+',NULL,''),
 (76,248,15,1,52,15,1,0.0000,'+',0,'+',0.00000000,'+',NULL,'');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_recurring`;
@@ -2352,8 +2200,6 @@ CREATE TABLE `oc_product_recurring` (
   `customer_group_id` int(11) NOT NULL,
   PRIMARY KEY (`product_id`,`recurring_id`,`customer_group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_recurring` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_related`;
@@ -2362,8 +2208,6 @@ CREATE TABLE `oc_product_related` (
   `related_id` int(11) NOT NULL,
   PRIMARY KEY (`product_id`,`related_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_related` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_reward`;
@@ -2376,8 +2220,6 @@ CREATE TABLE `oc_product_reward` (
   KEY `customer_group_id` (`customer_group_id`),
   KEY `product_id` (`product_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=547 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_reward` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_special`;
@@ -2396,8 +2238,6 @@ CREATE TABLE `oc_product_special` (
   KEY `date_end` (`date_end`),
   KEY `customer_group_id_2` (`customer_group_id`,`date_start`,`date_end`)
 ) ENGINE=InnoDB AUTO_INCREMENT=444 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_special` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_to_category`;
@@ -2407,7 +2247,6 @@ CREATE TABLE `oc_product_to_category` (
   PRIMARY KEY (`product_id`,`category_id`),
   KEY `category_id` (`category_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_to_category` WRITE;
 INSERT INTO `oc_product_to_category` VALUES
 (1,100),
 (2,100),
@@ -2424,7 +2263,6 @@ INSERT INTO `oc_product_to_category` VALUES
 (13,108),
 (14,109),
 (15,110);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_to_download`;
@@ -2433,8 +2271,6 @@ CREATE TABLE `oc_product_to_download` (
   `download_id` int(11) NOT NULL,
   PRIMARY KEY (`product_id`,`download_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_to_download` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_to_layout`;
@@ -2444,8 +2280,6 @@ CREATE TABLE `oc_product_to_layout` (
   `layout_id` int(11) NOT NULL,
   PRIMARY KEY (`product_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_to_layout` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_to_product`;
@@ -2456,8 +2290,6 @@ CREATE TABLE `oc_product_to_product` (
   PRIMARY KEY (`product_group_id`,`product_id`),
   KEY `product_id` (`product_id`,`default_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_to_product` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_product_to_store`;
@@ -2466,7 +2298,6 @@ CREATE TABLE `oc_product_to_store` (
   `store_id` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`product_id`,`store_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_product_to_store` WRITE;
 INSERT INTO `oc_product_to_store` VALUES
 (1,0),
 (2,0),
@@ -2483,7 +2314,6 @@ INSERT INTO `oc_product_to_store` VALUES
 (13,0),
 (14,0),
 (15,0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_recurring`;
@@ -2502,8 +2332,6 @@ CREATE TABLE `oc_recurring` (
   `sort_order` int(11) NOT NULL,
   PRIMARY KEY (`recurring_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_recurring` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_recurring_description`;
@@ -2513,8 +2341,6 @@ CREATE TABLE `oc_recurring_description` (
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`recurring_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_recurring_description` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_return`;
@@ -2540,8 +2366,6 @@ CREATE TABLE `oc_return` (
   `date_modified` datetime NOT NULL,
   PRIMARY KEY (`return_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_return` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_return_action`;
@@ -2551,12 +2375,10 @@ CREATE TABLE `oc_return_action` (
   `name` varchar(64) NOT NULL,
   PRIMARY KEY (`return_action_id`,`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_return_action` WRITE;
 INSERT INTO `oc_return_action` VALUES
 (1,1,'Refunded'),
 (2,1,'Credit Issued'),
 (3,1,'Replacement Sent');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_return_history`;
@@ -2569,8 +2391,6 @@ CREATE TABLE `oc_return_history` (
   `date_added` datetime NOT NULL,
   PRIMARY KEY (`return_history_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_return_history` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_return_reason`;
@@ -2580,14 +2400,12 @@ CREATE TABLE `oc_return_reason` (
   `name` varchar(128) NOT NULL,
   PRIMARY KEY (`return_reason_id`,`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_return_reason` WRITE;
 INSERT INTO `oc_return_reason` VALUES
 (1,1,'Dead On Arrival'),
 (2,1,'Received Wrong Item'),
 (3,1,'Order Error'),
 (4,1,'Faulty, please supply details'),
 (5,1,'Other, please supply details');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_return_status`;
@@ -2597,12 +2415,10 @@ CREATE TABLE `oc_return_status` (
   `name` varchar(32) NOT NULL,
   PRIMARY KEY (`return_status_id`,`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_return_status` WRITE;
 INSERT INTO `oc_return_status` VALUES
 (1,1,'Pending'),
 (2,1,'Awaiting Products'),
 (3,1,'Complete');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_search_register`;
@@ -2614,8 +2430,6 @@ CREATE TABLE `oc_search_register` (
   `result` int(11) NOT NULL,
   PRIMARY KEY (`search_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_search_register` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_search_table`;
@@ -2627,8 +2441,6 @@ CREATE TABLE `oc_search_table` (
   `language_id` tinyint(4) NOT NULL,
   `status` tinyint(4) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_search_table` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_search_types`;
@@ -2637,8 +2449,6 @@ CREATE TABLE `oc_search_types` (
   `name` varchar(254) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
   PRIMARY KEY (`type_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_uca1400_ai_ci;
-LOCK TABLES `oc_search_types` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_setting`;
@@ -2652,7 +2462,6 @@ CREATE TABLE `oc_setting` (
   PRIMARY KEY (`setting_id`),
   KEY `store_id` (`store_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=177 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_setting` WRITE;
 INSERT INTO `oc_setting` VALUES
 (1,0,'config','config_robots','abot\r\ndbot\r\nebot\r\nhbot\r\nkbot\r\nlbot\r\nmbot\r\nnbot\r\nobot\r\npbot\r\nrbot\r\nsbot\r\ntbot\r\nvbot\r\nybot\r\nzbot\r\nbot.\r\nbot/\r\n_bot\r\n.bot\r\n/bot\r\n-bot\r\n:bot\r\n(bot\r\ncrawl\r\nslurp\r\nspider\r\nseek\r\naccoona\r\nacoon\r\nadressendeutschland\r\nah-ha.com\r\nahoy\r\naltavista\r\nananzi\r\nanthill\r\nappie\r\narachnophilia\r\narale\r\naraneo\r\naranha\r\narchitext\r\naretha\r\narks\r\nasterias\r\natlocal\r\natn\r\natomz\r\naugurfind\r\nbackrub\r\nbannana_bot\r\nbaypup\r\nbdfetch\r\nbig brother\r\nbiglotron\r\nbjaaland\r\nblackwidow\r\nblaiz\r\nblog\r\nblo.\r\nbloodhound\r\nboitho\r\nbooch\r\nbradley\r\nbutterfly\r\ncalif\r\ncassandra\r\nccubee\r\ncfetch\r\ncharlotte\r\nchurl\r\ncienciaficcion\r\ncmc\r\ncollective\r\ncomagent\r\ncombine\r\ncomputingsite\r\ncsci\r\ncurl\r\ncusco\r\ndaumoa\r\ndeepindex\r\ndelorie\r\ndepspid\r\ndeweb\r\ndie blinde kuh\r\ndigger\r\nditto\r\ndmoz\r\ndocomo\r\ndownload express\r\ndtaagent\r\ndwcp\r\nebiness\r\nebingbong\r\ne-collector\r\nejupiter\r\nemacs-w3 search engine\r\nesther\r\nevliya celebi\r\nezresult\r\nfalcon\r\nfelix ide\r\nferret\r\nfetchrover\r\nfido\r\nfindlinks\r\nfireball\r\nfish search\r\nfouineur\r\nfunnelweb\r\ngazz\r\ngcreep\r\ngenieknows\r\ngetterroboplus\r\ngeturl\r\nglx\r\ngoforit\r\ngolem\r\ngrabber\r\ngrapnel\r\ngralon\r\ngriffon\r\ngromit\r\ngrub\r\ngulliver\r\nhamahakki\r\nharvest\r\nhavindex\r\nhelix\r\nheritrix\r\nhku www octopus\r\nhomerweb\r\nhtdig\r\nhtml index\r\nhtml_analyzer\r\nhtmlgobble\r\nhubater\r\nhyper-decontextualizer\r\nia_archiver\r\nibm_planetwide\r\nichiro\r\niconsurf\r\niltrovatore\r\nimage.kapsi.net\r\nimagelock\r\nincywincy\r\nindexer\r\ninfobee\r\ninformant\r\ningrid\r\ninktomisearch.com\r\ninspector web\r\nintelliagent\r\ninternet shinchakubin\r\nip3000\r\niron33\r\nisraeli-search\r\nivia\r\njack\r\njakarta\r\njavabee\r\njetbot\r\njumpstation\r\nkatipo\r\nkdd-explorer\r\nkilroy\r\nknowledge\r\nkototoi\r\nkretrieve\r\nlabelgrabber\r\nlachesis\r\nlarbin\r\nlegs\r\nlibwww\r\nlinkalarm\r\nlink validator\r\nlinkscan\r\nlockon\r\nlwp\r\nlycos\r\nmagpie\r\nmantraagent\r\nmapoftheinternet\r\nmarvin/\r\nmattie\r\nmediafox\r\nmediapartners\r\nmercator\r\nmerzscope\r\nmicrosoft url control\r\nminirank\r\nmiva\r\nmj12\r\nmnogosearch\r\nmoget\r\nmonster\r\nmoose\r\nmotor\r\nmultitext\r\nmuncher\r\nmuscatferret\r\nmwd.search\r\nmyweb\r\nnajdi\r\nnameprotect\r\nnationaldirectory\r\nnazilla\r\nncsa beta\r\nnec-meshexplorer\r\nnederland.zoek\r\nnetcarta webmap engine\r\nnetmechanic\r\nnetresearchserver\r\nnetscoop\r\nnewscan-online\r\nnhse\r\nnokia6682/\r\nnomad\r\nnoyona\r\nnutch\r\nnzexplorer\r\nobjectssearch\r\noccam\r\nomni\r\nopen text\r\nopenfind\r\nopenintelligencedata\r\norb search\r\nosis-project\r\npack rat\r\npageboy\r\npagebull\r\npage_verifier\r\npanscient\r\nparasite\r\npartnersite\r\npatric\r\npear.\r\npegasus\r\nperegrinator\r\npgp key agent\r\nphantom\r\nphpdig\r\npicosearch\r\npiltdownman\r\npimptrain\r\npinpoint\r\npioneer\r\npiranha\r\nplumtreewebaccessor\r\npogodak\r\npoirot\r\npompos\r\npoppelsdorf\r\npoppi\r\npopular iconoclast\r\npsycheclone\r\npublisher\r\npython\r\nrambler\r\nraven search\r\nroach\r\nroad runner\r\nroadhouse\r\nrobbie\r\nrobofox\r\nrobozilla\r\nrules\r\nsalty\r\nsbider\r\nscooter\r\nscoutjet\r\nscrubby\r\nsearch.\r\nsearchprocess\r\nsemanticdiscovery\r\nsenrigan\r\nsg-scout\r\nshai\'hulud\r\nshark\r\nshopwiki\r\nsidewinder\r\nsift\r\nsilk\r\nsimmany\r\nsite searcher\r\nsite valet\r\nsitetech-rover\r\nskymob.com\r\nsleek\r\nsmartwit\r\nsna-\r\nsnappy\r\nsnooper\r\nsohu\r\nspeedfind\r\nsphere\r\nsphider\r\nspinner\r\nspyder\r\nsteeler/\r\nsuke\r\nsuntek\r\nsupersnooper\r\nsurfnomore\r\nsven\r\nsygol\r\nszukacz\r\ntach black widow\r\ntarantula\r\ntempleton\r\n/teoma\r\nt-h-u-n-d-e-r-s-t-o-n-e\r\ntheophrastus\r\ntitan\r\ntitin\r\ntkwww\r\ntoutatis\r\nt-rex\r\ntutorgig\r\ntwiceler\r\ntwisted\r\nucsd\r\nudmsearch\r\nurl check\r\nupdated\r\nvagabondo\r\nvalkyrie\r\nverticrawl\r\nvictoria\r\nvision-search\r\nvolcano\r\nvoyager/\r\nvoyager-hc\r\nw3c_validator\r\nw3m2\r\nw3mir\r\nwalker\r\nwallpaper\r\nwanderer\r\nwauuu\r\nwavefire\r\nweb core\r\nweb hopper\r\nweb wombat\r\nwebbandit\r\nwebcatcher\r\nwebcopy\r\nwebfoot\r\nweblayers\r\nweblinker\r\nweblog monitor\r\nwebmirror\r\nwebmonkey\r\nwebquest\r\nwebreaper\r\nwebsitepulse\r\nwebsnarf\r\nwebstolperer\r\nwebvac\r\nwebwalk\r\nwebwatch\r\nwebwombat\r\nwebzinger\r\nwhizbang\r\nwhowhere\r\nwild ferret\r\nworldlight\r\nwwwc\r\nwwwster\r\nxenu\r\nxget\r\nxift\r\nxirq\r\nyandex\r\nyanga\r\nyeti\r\nyodao\r\nzao\r\nzippp\r\nzyborg',0),
 (2,0,'config','config_shared','0',0),
@@ -2827,7 +2636,6 @@ INSERT INTO `oc_setting` VALUES
 (174,0,'config','config_email','admin@example.com',0),
 (175,0,'config','config_encryption','0fFBDovjQbKswTSu3pT7lW1blwWCzLdW1F5L7IiAL5PMxfRIwUk8WEWGcoAgXDSZzGtht3fvSzv70CsinAW2a8ghnUS2SPyNqFgJn9KQ0dKGFXTkv1wiH3CirFZYImT8RtCYKKglqzttgkQCZqZVTWFggvkH3OkiwyguiR9JLZNF0lmgF16QcND0ag0PMX78WjgPTjBRuSSxrZ7t0fZQWLySP92VcKeKvReqgZJbckVTKIXdECgTyrhxoEhKVgloqZluCEv1wjSQoyZV3zauY0zXWLtE2e2QH7IO5OLsuuyX0hQibUe2wOdIJpMW9Ri6OcAzWFbIIPMHXx9ged1lVCz8G5g7pLwrGmZkRtTgBU9nJWt4MAvDoUIcD6wRqMPC5J3WMoJ24NuUS6RtVnJFuskOBLJI3HctagmeDzgS8E1D028E11roayMDWgv0OS8kySSOYb55lDPgF2DhkRgQBhxAi2eBjT6x2VJTSRUiE3jgG3f1pAXnc55ss3PyMOwPGV7NlAcUIv6iYumFFlgk1GKLVTLYpqBbSQrvWzM422ZTZ8NrQkbH6IvtsJja2yto1jVmxZJljKxjETgFigDReIXKFIZ95rBUfTcwfMymLYb4NQFtExJ3ds2iK3cIvw0Fp0GATEOFjsmd31DLckfVBz6mCti6OjdS9JnmPL19ycBuDLOGIxDcD5vd4q9JxwzlTsF3OSUwxoHfAkQHjvkJebxS3dgaA1UPD1645lrxd79ZuHSqRs1SfVUad0VD8pP4oOcGp4fNmK52nBLqCR0i6BDLOaZlAXAMvDeEqNM3zo5LtU6Wq22U7bdEn8X7M6qEoJZfzuLUknBA3jZEYAaLz4KPKgyeLuwx44P2nGn3ydZepvY0nlReAzzeeNH7VpI483nQB8qAsPeFkZZzzbpYzZFaKnKOn0fyFmmllvNYXeJcRtLpIPUriwZsKFrWKiqTQQwW8Tp7qZ4rsSEPA6r5h2A1OzEwxIVzaUnU9fVqv7pUxIHaUe0j6ykbQV3MNOhc',0),
 (176,0,'config','config_api_id','1',0);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_stock_status`;
@@ -2837,13 +2645,11 @@ CREATE TABLE `oc_stock_status` (
   `name` varchar(32) NOT NULL,
   PRIMARY KEY (`stock_status_id`,`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_stock_status` WRITE;
 INSERT INTO `oc_stock_status` VALUES
 (5,1,'Out Of Stock'),
 (6,1,'2-3 Days'),
 (7,1,'In Stock'),
 (8,1,'Pre-Order');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_store`;
@@ -2855,8 +2661,6 @@ CREATE TABLE `oc_store` (
   PRIMARY KEY (`store_id`),
   KEY `url` (`url`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_store` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_tax_class`;
@@ -2868,11 +2672,9 @@ CREATE TABLE `oc_tax_class` (
   `date_modified` datetime NOT NULL,
   PRIMARY KEY (`tax_class_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_tax_class` WRITE;
 INSERT INTO `oc_tax_class` VALUES
 (9,'Taxable Goods','Taxed goods','2009-01-06 23:21:53','2011-09-23 14:07:50'),
 (10,'Downloadable Products','Downloadable','2011-09-21 22:19:39','2011-09-22 10:27:36');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_tax_rate`;
@@ -2886,11 +2688,9 @@ CREATE TABLE `oc_tax_rate` (
   `date_modified` datetime NOT NULL,
   PRIMARY KEY (`tax_rate_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=88 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_tax_rate` WRITE;
 INSERT INTO `oc_tax_rate` VALUES
 (86,3,'VAT (20%)',20.0000,'P','2011-03-09 21:17:10','2011-09-22 22:24:29'),
 (87,3,'Eco Tax (-2.00)',2.0000,'F','2011-09-21 21:49:23','2011-09-23 00:40:19');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_tax_rate_to_customer_group`;
@@ -2899,11 +2699,9 @@ CREATE TABLE `oc_tax_rate_to_customer_group` (
   `customer_group_id` int(11) NOT NULL,
   PRIMARY KEY (`tax_rate_id`,`customer_group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_tax_rate_to_customer_group` WRITE;
 INSERT INTO `oc_tax_rate_to_customer_group` VALUES
 (86,1),
 (87,1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_tax_rule`;
@@ -2915,13 +2713,11 @@ CREATE TABLE `oc_tax_rule` (
   `priority` int(5) NOT NULL DEFAULT 1,
   PRIMARY KEY (`tax_rule_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=129 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_tax_rule` WRITE;
 INSERT INTO `oc_tax_rule` VALUES
 (120,10,87,'store',0),
 (121,10,86,'payment',1),
 (127,9,87,'shipping',2),
 (128,9,86,'shipping',1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_theme`;
@@ -2933,8 +2729,6 @@ CREATE TABLE `oc_theme` (
   `code` text NOT NULL,
   PRIMARY KEY (`theme_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_theme` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_translation`;
@@ -2947,8 +2741,6 @@ CREATE TABLE `oc_translation` (
   `value` text NOT NULL,
   PRIMARY KEY (`translation_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_translation` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_url_alias`;
@@ -2962,7 +2754,6 @@ CREATE TABLE `oc_url_alias` (
   KEY `keyword` (`keyword`),
   KEY `language_id` (`language_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=872 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_url_alias` WRITE;
 INSERT INTO `oc_url_alias` VALUES
 (730,'manufacturer_id=8','apple',0),
 (772,'information_id=4','about_us',0),
@@ -3000,7 +2791,6 @@ INSERT INTO `oc_url_alias` VALUES
 (869,'product_id=13','xbox-series-x',1),
 (870,'product_id=14','logitech-mx-master-3s',1),
 (871,'product_id=15','apple-homepod-mini',1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_user_group`;
@@ -3010,11 +2800,9 @@ CREATE TABLE `oc_user_group` (
   `permission` text NOT NULL,
   PRIMARY KEY (`user_group_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_user_group` WRITE;
 INSERT INTO `oc_user_group` VALUES
 (1,'Administrator','{\"access\":[\"catalog/attribute\",\"catalog/attribute_group\",\"catalog/category\",\"catalog/download\",\"catalog/filter\",\"catalog/information\",\"catalog/manufacturer\",\"catalog/option\",\"catalog/product\",\"catalog/recurring\",\"catalog/review\",\"common/column_left\",\"common/filemanager\",\"customer/custom_field\",\"customer/customer\",\"customer/customer_group\",\"design/banner\",\"design/language\",\"design/layout\",\"design/menu\",\"design/theme\",\"design/translation\",\"event/compatibility\",\"event/theme\",\"extension/analytics/google_analytics\",\"extension/captcha/basic_captcha\",\"extension/captcha/google_captcha\",\"extension/dashboard/activity\",\"extension/dashboard/chart\",\"extension/dashboard/customer\",\"extension/dashboard/map\",\"extension/dashboard/online\",\"extension/dashboard/order\",\"extension/dashboard/recent\",\"extension/dashboard/sale\",\"extension/event\",\"extension/extension\",\"extension/extension/analytics\",\"extension/extension/captcha\",\"extension/extension/dashboard\",\"extension/extension/feed\",\"extension/extension/fraud\",\"extension/extension/menu\",\"extension/extension/module\",\"extension/extension/payment\",\"extension/extension/shipping\",\"extension/extension/theme\",\"extension/extension/total\",\"extension/feed/google_base\",\"extension/feed/google_sitemap\",\"extension/fraud/fraudlabspro\",\"extension/fraud/ip\",\"extension/fraud/maxmind\",\"extension/installer\",\"extension/modification\",\"extension/module/account\",\"extension/module/affiliate\",\"extension/module/amazon_login\",\"extension/module/amazon_pay\",\"extension/module/banner\",\"extension/module/bestseller\",\"extension/module/carousel\",\"extension/module/category\",\"extension/module/divido_calculator\",\"extension/module/ebay_listing\",\"extension/module/featured\",\"extension/module/filter\",\"extension/module/google_hangouts\",\"extension/module/html\",\"extension/module/information\",\"extension/module/klarna_checkout_module\",\"extension/module/latest\",\"extension/module/laybuy_layout\",\"extension/module/pilibaba_button\",\"extension/module/pp_button\",\"extension/module/pp_login\",\"extension/module/sagepay_direct_cards\",\"extension/module/sagepay_server_cards\",\"extension/module/slideshow\",\"extension/module/special\",\"extension/module/store\",\"extension/payment/amazon_login_pay\",\"extension/payment/authorizenet_aim\",\"extension/payment/authorizenet_sim\",\"extension/payment/bank_transfer\",\"extension/payment/bluepay_hosted\",\"extension/payment/bluepay_redirect\",\"extension/payment/cardconnect\",\"extension/payment/cardinity\",\"extension/payment/cheque\",\"extension/payment/cod\",\"extension/payment/divido\",\"extension/payment/eway\",\"extension/payment/firstdata\",\"extension/payment/firstdata_remote\",\"extension/payment/free_checkout\",\"extension/payment/g2apay\",\"extension/payment/globalpay\",\"extension/payment/globalpay_remote\",\"extension/payment/klarna_account\",\"extension/payment/klarna_checkout\",\"extension/payment/klarna_invoice\",\"extension/payment/laybuy\",\"extension/payment/liqpay\",\"extension/payment/nochex\",\"extension/payment/paymate\",\"extension/payment/paypoint\",\"extension/payment/payza\",\"extension/payment/perpetual_payments\",\"extension/payment/pilibaba\",\"extension/payment/pp_express\",\"extension/payment/pp_payflow\",\"extension/payment/pp_payflow_iframe\",\"extension/payment/pp_pro\",\"extension/payment/pp_pro_iframe\",\"extension/payment/pp_standard\",\"extension/payment/realex\",\"extension/payment/realex_remote\",\"extension/payment/sagepay_direct\",\"extension/payment/sagepay_server\",\"extension/payment/sagepay_us\",\"extension/payment/securetrading_pp\",\"extension/payment/securetrading_ws\",\"extension/payment/skrill\",\"extension/payment/twocheckout\",\"extension/payment/web_payment_software\",\"extension/payment/worldpay\",\"extension/shipping/auspost\",\"extension/shipping/citylink\",\"extension/shipping/fedex\",\"extension/shipping/flat\",\"extension/shipping/free\",\"extension/shipping/item\",\"extension/shipping/parcelforce_48\",\"extension/shipping/pickup\",\"extension/shipping/royal_mail\",\"extension/shipping/ups\",\"extension/shipping/usps\",\"extension/shipping/weight\",\"extension/store\",\"extension/theme/theme_default\",\"extension/total/coupon\",\"extension/total/credit\",\"extension/total/handling\",\"extension/total/klarna_fee\",\"extension/total/low_order_fee\",\"extension/total/reward\",\"extension/total/shipping\",\"extension/total/sub_total\",\"extension/total/tax\",\"extension/total/total\",\"extension/total/voucher\",\"localisation/country\",\"localisation/currency\",\"localisation/geo_zone\",\"localisation/language\",\"localisation/length_class\",\"localisation/location\",\"localisation/order_status\",\"localisation/return_action\",\"localisation/return_reason\",\"localisation/return_status\",\"localisation/stock_status\",\"localisation/tax_class\",\"localisation/tax_rate\",\"localisation/weight_class\",\"localisation/zone\",\"marketing/affiliate\",\"marketing/contact\",\"marketing/coupon\",\"marketing/marketing\",\"report/affiliate\",\"report/affiliate_activity\",\"report/affiliate_login\",\"report/customer_activity\",\"report/customer_credit\",\"report/customer_login\",\"report/customer_online\",\"report/customer_order\",\"report/customer_reward\",\"report/customer_search\",\"report/marketing\",\"report/product_purchased\",\"report/product_viewed\",\"report/sale_coupon\",\"report/sale_order\",\"report/sale_return\",\"report/sale_shipping\",\"report/sale_tax\",\"sale/order\",\"sale/recurring\",\"sale/return\",\"sale/voucher\",\"sale/voucher_theme\",\"setting/setting\",\"setting/store\",\"startup/compatibility\",\"startup/error\",\"startup/event\",\"startup/login\",\"startup/permission\",\"startup/router\",\"startup/sass\",\"startup/startup\",\"tool/backup\",\"tool/log\",\"tool/upload\",\"user/api\",\"user/user\",\"user/user_permission\",\"extension/module/cr_translate_mate\"],\"modify\":[\"catalog/attribute\",\"catalog/attribute_group\",\"catalog/category\",\"catalog/download\",\"catalog/filter\",\"catalog/information\",\"catalog/manufacturer\",\"catalog/option\",\"catalog/product\",\"catalog/recurring\",\"catalog/review\",\"common/column_left\",\"common/filemanager\",\"customer/custom_field\",\"customer/customer\",\"customer/customer_group\",\"design/banner\",\"design/language\",\"design/layout\",\"design/menu\",\"design/theme\",\"design/translation\",\"event/compatibility\",\"event/theme\",\"extension/analytics/google_analytics\",\"extension/captcha/basic_captcha\",\"extension/captcha/google_captcha\",\"extension/dashboard/activity\",\"extension/dashboard/chart\",\"extension/dashboard/customer\",\"extension/dashboard/map\",\"extension/dashboard/online\",\"extension/dashboard/order\",\"extension/dashboard/recent\",\"extension/dashboard/sale\",\"extension/event\",\"extension/extension\",\"extension/extension/analytics\",\"extension/extension/captcha\",\"extension/extension/dashboard\",\"extension/extension/feed\",\"extension/extension/fraud\",\"extension/extension/menu\",\"extension/extension/module\",\"extension/extension/payment\",\"extension/extension/shipping\",\"extension/extension/theme\",\"extension/extension/total\",\"extension/feed/google_base\",\"extension/feed/google_sitemap\",\"extension/fraud/fraudlabspro\",\"extension/fraud/ip\",\"extension/fraud/maxmind\",\"extension/installer\",\"extension/modification\",\"extension/module/account\",\"extension/module/affiliate\",\"extension/module/amazon_login\",\"extension/module/amazon_pay\",\"extension/module/banner\",\"extension/module/bestseller\",\"extension/module/carousel\",\"extension/module/category\",\"extension/module/divido_calculator\",\"extension/module/ebay_listing\",\"extension/module/featured\",\"extension/module/filter\",\"extension/module/google_hangouts\",\"extension/module/html\",\"extension/module/information\",\"extension/module/klarna_checkout_module\",\"extension/module/latest\",\"extension/module/laybuy_layout\",\"extension/module/pilibaba_button\",\"extension/module/pp_button\",\"extension/module/pp_login\",\"extension/module/sagepay_direct_cards\",\"extension/module/sagepay_server_cards\",\"extension/module/slideshow\",\"extension/module/special\",\"extension/module/store\",\"extension/payment/amazon_login_pay\",\"extension/payment/authorizenet_aim\",\"extension/payment/authorizenet_sim\",\"extension/payment/bank_transfer\",\"extension/payment/bluepay_hosted\",\"extension/payment/bluepay_redirect\",\"extension/payment/cardconnect\",\"extension/payment/cardinity\",\"extension/payment/cheque\",\"extension/payment/cod\",\"extension/payment/divido\",\"extension/payment/eway\",\"extension/payment/firstdata\",\"extension/payment/firstdata_remote\",\"extension/payment/free_checkout\",\"extension/payment/g2apay\",\"extension/payment/globalpay\",\"extension/payment/globalpay_remote\",\"extension/payment/klarna_account\",\"extension/payment/klarna_checkout\",\"extension/payment/klarna_invoice\",\"extension/payment/laybuy\",\"extension/payment/liqpay\",\"extension/payment/nochex\",\"extension/payment/paymate\",\"extension/payment/paypoint\",\"extension/payment/payza\",\"extension/payment/perpetual_payments\",\"extension/payment/pilibaba\",\"extension/payment/pp_express\",\"extension/payment/pp_payflow\",\"extension/payment/pp_payflow_iframe\",\"extension/payment/pp_pro\",\"extension/payment/pp_pro_iframe\",\"extension/payment/pp_standard\",\"extension/payment/realex\",\"extension/payment/realex_remote\",\"extension/payment/sagepay_direct\",\"extension/payment/sagepay_server\",\"extension/payment/sagepay_us\",\"extension/payment/securetrading_pp\",\"extension/payment/securetrading_ws\",\"extension/payment/skrill\",\"extension/payment/twocheckout\",\"extension/payment/web_payment_software\",\"extension/payment/worldpay\",\"extension/shipping/auspost\",\"extension/shipping/citylink\",\"extension/shipping/fedex\",\"extension/shipping/flat\",\"extension/shipping/free\",\"extension/shipping/item\",\"extension/shipping/parcelforce_48\",\"extension/shipping/pickup\",\"extension/shipping/royal_mail\",\"extension/shipping/ups\",\"extension/shipping/usps\",\"extension/shipping/weight\",\"extension/store\",\"extension/theme/theme_default\",\"extension/total/coupon\",\"extension/total/credit\",\"extension/total/handling\",\"extension/total/klarna_fee\",\"extension/total/low_order_fee\",\"extension/total/reward\",\"extension/total/shipping\",\"extension/total/sub_total\",\"extension/total/tax\",\"extension/total/total\",\"extension/total/voucher\",\"localisation/country\",\"localisation/currency\",\"localisation/geo_zone\",\"localisation/language\",\"localisation/length_class\",\"localisation/location\",\"localisation/order_status\",\"localisation/return_action\",\"localisation/return_reason\",\"localisation/return_status\",\"localisation/stock_status\",\"localisation/tax_class\",\"localisation/tax_rate\",\"localisation/weight_class\",\"localisation/zone\",\"marketing/affiliate\",\"marketing/contact\",\"marketing/coupon\",\"marketing/marketing\",\"report/affiliate\",\"report/affiliate_activity\",\"report/affiliate_login\",\"report/customer_activity\",\"report/customer_credit\",\"report/customer_login\",\"report/customer_online\",\"report/customer_order\",\"report/customer_reward\",\"report/customer_search\",\"report/marketing\",\"report/product_purchased\",\"report/product_viewed\",\"report/sale_coupon\",\"report/sale_order\",\"report/sale_return\",\"report/sale_shipping\",\"report/sale_tax\",\"sale/order\",\"sale/recurring\",\"sale/return\",\"sale/voucher\",\"sale/voucher_theme\",\"setting/setting\",\"setting/store\",\"startup/compatibility\",\"startup/error\",\"startup/event\",\"startup/login\",\"startup/permission\",\"startup/router\",\"startup/sass\",\"startup/startup\",\"tool/backup\",\"tool/log\",\"tool/upload\",\"user/api\",\"user/user\",\"user/user_permission\",\"extension/module/cr_translate_mate\"]}'),
 (10,'Demonstration','');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_voucher_theme`;
@@ -3023,12 +2811,10 @@ CREATE TABLE `oc_voucher_theme` (
   `image` varchar(255) NOT NULL,
   PRIMARY KEY (`voucher_theme_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_voucher_theme` WRITE;
 INSERT INTO `oc_voucher_theme` VALUES
 (6,'catalog/demo/apple_logo.jpg'),
 (7,'catalog/demo/gift-voucher-birthday.jpg'),
 (8,'catalog/demo/canon_eos_5d_2.jpg');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_voucher_theme_description`;
@@ -3038,12 +2824,10 @@ CREATE TABLE `oc_voucher_theme_description` (
   `name` varchar(32) NOT NULL,
   PRIMARY KEY (`voucher_theme_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_voucher_theme_description` WRITE;
 INSERT INTO `oc_voucher_theme_description` VALUES
 (6,1,'Christmas'),
 (7,1,'Birthday'),
 (8,1,'General');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_webform`;
@@ -3064,8 +2848,6 @@ CREATE TABLE `oc_webform` (
   `language_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_webform` WRITE;
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_weight_class`;
@@ -3074,13 +2856,11 @@ CREATE TABLE `oc_weight_class` (
   `value` decimal(15,8) NOT NULL DEFAULT 0.00000000,
   PRIMARY KEY (`weight_class_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_weight_class` WRITE;
 INSERT INTO `oc_weight_class` VALUES
 (1,1.00000000),
 (2,1000.00000000),
 (5,2.20460000),
 (6,35.27400000);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_weight_class_description`;
@@ -3091,13 +2871,11 @@ CREATE TABLE `oc_weight_class_description` (
   `unit` varchar(4) NOT NULL,
   PRIMARY KEY (`weight_class_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_weight_class_description` WRITE;
 INSERT INTO `oc_weight_class_description` VALUES
 (1,1,'Kilogram','kg'),
 (2,1,'Gram','g'),
 (5,1,'Pound ','lb'),
 (6,1,'Ounce','oz');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_zone`;
@@ -3109,7 +2887,6 @@ CREATE TABLE `oc_zone` (
   `status` tinyint(1) NOT NULL DEFAULT 1,
   PRIMARY KEY (`zone_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4239 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_zone` WRITE;
 INSERT INTO `oc_zone` VALUES
 (1,1,'Badakhshan','BDS',1),
 (2,1,'Badghis','BDG',1),
@@ -7219,7 +6996,6 @@ INSERT INTO `oc_zone` VALUES
 (4236,105,'Barletta-Andria-Trani','BT',1),
 (4237,105,'Fermo','FM',1),
 (4238,105,'Monza Brianza','MB',1);
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 DROP TABLE IF EXISTS `oc_zone_to_geo_zone`;
@@ -7232,7 +7008,6 @@ CREATE TABLE `oc_zone_to_geo_zone` (
   `date_modified` datetime NOT NULL,
   PRIMARY KEY (`zone_to_geo_zone_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=110 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
-LOCK TABLES `oc_zone_to_geo_zone` WRITE;
 INSERT INTO `oc_zone_to_geo_zone` VALUES
 (1,222,0,4,'0000-00-00 00:00:00','0000-00-00 00:00:00'),
 (2,222,3513,3,'0000-00-00 00:00:00','0000-00-00 00:00:00'),
@@ -7343,7 +7118,6 @@ INSERT INTO `oc_zone_to_geo_zone` VALUES
 (107,222,3954,3,'0000-00-00 00:00:00','0000-00-00 00:00:00'),
 (108,222,3955,3,'0000-00-00 00:00:00','0000-00-00 00:00:00'),
 (109,222,3972,3,'0000-00-00 00:00:00','0000-00-00 00:00:00');
-UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=@OLD_AUTOCOMMIT;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Summary

- Removes 226 `LOCK TABLES` / `UNLOCK TABLES` lines from `migrations/structure.sql`
- These are emitted by mysqldump but the installer's prefix-replacement only handles `DROP/CREATE/INSERT/ALTER TABLE`, so `LOCK TABLES \`oc_address\` WRITE` kept the original `oc_` prefix and caused "Table doesn't exist" errors on fresh install
- No functional change to schema or data

## Test plan

- [ ] Fresh install completes without errors via `php copona install --no-interaction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)