### PR TITLE
Fix phinx.php CLI detection: use PHP_SAPI instead of $_SERVER['SHELL']

### DIFF
--- a/phinx.php
+++ b/phinx.php
@@ -2,10 +2,9 @@
 
 
 
-if(!isset( $_SERVER['SHELL'] )) {
-    echo "Continue from console - run Phinx migration (currently - the only way to run it is from console!...";
-    echo "<pre>vendor/bin/phinx migrate</pre>";
-    die("\n\nInstallation probably done... Ensure to run Phinx!");
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit('Forbidden');
 }
 
 if (!defined('DIR_COPONA')) {


### PR DESCRIPTION
## Summary

- Replaces `!isset($_SERVER['SHELL'])` guard with `PHP_SAPI !== 'cli'`
- `$_SERVER['SHELL']` is not set in `docker exec` contexts or any non-login shell, causing `phinx.php` to `die()` with a "run from console" message during legitimate CLI installs
- `PHP_SAPI === 'cli'` is the correct portable way to detect CLI context
- The guard still blocks web requests from reaching the phinx config (returns 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)