### PR TITLE
Fix storage directory permissions via entrypoint hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,10 @@ RUN echo display_errors = On >> /opt/docker/etc/php/php.ini
 RUN echo error_reporting = E_ALL >> /opt/docker/etc/php/php.ini
 RUN echo display_startup_errors = On >> /opt/docker/etc/php/php.ini
 RUN mkdir -p /var/lib/php/session && chmod 777 /var/lib/php/session
-RUN mkdir -p /app/storage/public/cache/image \
-    /app/storage/public/cache \
-    /app/storage/private/cache \
-    /app/storage/private/logs \
-    /app/storage/private/download \
-    /app/storage/private/upload \
-    /app/storage/private/modification \
-    && chmod -R 777 /app/storage
+# Create storage dirs at container startup (runs after volume mount so host dirs get the right perms)
+RUN printf '#!/bin/sh\nmkdir -p \\\n  /app/storage/public/cache/image \\\n  /app/storage/public/cache \\\n  /app/storage/private/cache \\\n  /app/storage/private/logs \\\n  /app/storage/private/download \\\n  /app/storage/private/upload \\\n  /app/storage/private/modification\nchmod -R 777 /app/storage\n' \
+    > /opt/docker/provision/entrypoint.d/10-storage-init.sh \
+    && chmod +x /opt/docker/provision/entrypoint.d/10-storage-init.sh
 
 # xdebug 3.x config (xdebug 2.x ini keys removed in xdebug 3)
 RUN echo "xdebug.mode = off" >> /opt/docker/etc/php/php.ini


### PR DESCRIPTION
## Summary

- Moves storage directory creation from `RUN mkdir` (build time) to an `entrypoint.d` startup script (runtime)
- The `.:/app` volume mount in docker-compose hides anything created in the image at `/app`, so `mkdir + chmod` at build time had no effect on the mounted host directory
- The entrypoint script runs on every `docker compose up` after the volume is mounted, creating any missing dirs and setting `chmod 777` on `storage/`
- Fixes "Permission denied" errors on all `storage/private/logs/*` files that broke the frontend on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)