### PR TITLE
Fix log.php crash and storage file permission errors on fresh install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN echo error_reporting = E_ALL >> /opt/docker/etc/php/php.ini
 RUN echo display_startup_errors = On >> /opt/docker/etc/php/php.ini
 RUN mkdir -p /var/lib/php/session && chmod 777 /var/lib/php/session
 # Create storage dirs at container startup (runs after volume mount so host dirs get the right perms)
-RUN printf '#!/bin/sh\nmkdir -p \\\n  /app/storage/public/cache/image \\\n  /app/storage/public/cache \\\n  /app/storage/private/cache \\\n  /app/storage/private/logs \\\n  /app/storage/private/download \\\n  /app/storage/private/upload \\\n  /app/storage/private/modification\nchmod -R 777 /app/storage\n' \
+RUN printf '#!/bin/sh\nmkdir -p \\\n  /app/storage/public/cache/image \\\n  /app/storage/public/cache \\\n  /app/storage/private/cache \\\n  /app/storage/private/logs \\\n  /app/storage/private/download \\\n  /app/storage/private/upload \\\n  /app/storage/private/modification\nchmod -R 777 /app/storage\nfind /app/storage -type f -exec chmod 666 {} +\n' \
     > /opt/docker/provision/entrypoint.d/10-storage-init.sh \
     && chmod +x /opt/docker/provision/entrypoint.d/10-storage-init.sh
 

--- a/system/library/log.php
+++ b/system/library/log.php
@@ -3,21 +3,24 @@ class Log {
     private $handle;
 
     public function __construct($filename) {
-
-        if(!is_dir(DIR_LOGS)) {
+        if (!is_dir(DIR_LOGS)) {
             mkdir(DIR_LOGS, \Config::get('directory_permission', 0777), true);
         }
 
-        $this->handle = fopen(DIR_LOGS . $filename, 'a');
+        $this->handle = @fopen(DIR_LOGS . $filename, 'a') ?: null;
     }
 
     public function write($message) {
-        fwrite($this->handle, date('Y-m-d G:i:s') . ' - ' . print_r($message, true) . " in "
-                              . debug_backtrace()[0]['file'] . " on line " . debug_backtrace()[0]['line'] .  "\n");
+        if ($this->handle) {
+            fwrite($this->handle, date('Y-m-d G:i:s') . ' - ' . print_r($message, true) . " in "
+                . debug_backtrace()[0]['file'] . " on line " . debug_backtrace()[0]['line'] . "\n");
+        }
     }
 
     public function __destruct() {
-        fclose($this->handle);
+        if ($this->handle) {
+            fclose($this->handle);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- **`system/library/log.php`**: `fopen()` was called without `@` and without a null-check guard; if it returned `false` (e.g. log file root-owned 644), `fwrite()` and `fclose()` both threw `TypeError` and crashed the page. Now uses `@fopen() ?: null` and guards every call.
- **`Dockerfile` entrypoint**: Added `find /app/storage -type f -exec chmod 666 {} +` so pre-existing files with wrong ownership (created by root via `docker exec`) are made world-writable before Apache starts.

Root cause: `docker exec` defaults to root, so CLI installs create log files owned by root. PHP-FPM runs as `application` (uid 1000) and cannot write to root-owned 644 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)