### PR TITLE
chore: dos2unix, .gitattributes, PHP CS Fixer, PHPStan

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,37 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/catalog',
+        __DIR__ . '/admin',
+        __DIR__ . '/system',
+        __DIR__ . '/themes',
+        __DIR__ . '/install',
+    ])
+    ->name('*.php')
+    ->exclude([
+        'view/javascript/ckeditor',
+        'view/javascript/jquery',
+        'view/javascript/summernote',
+    ])
+    ->notPath([
+        'view/javascript/common.js',
+    ]);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12'                             => true,
+        'array_syntax'                       => ['syntax' => 'short'],
+        'no_unused_imports'                  => true,
+        'ordered_imports'                    => ['sort_algorithm' => 'alpha'],
+        'no_extra_blank_lines'               => true,
+        'trailing_comma_in_multiline'        => true,
+        'single_quote'                       => true,
+        'no_whitespace_in_blank_line'        => true,
+        'blank_line_after_namespace'         => true,
+        'object_operator_without_whitespace' => true,
+        'binary_operator_spaces'             => true,
+        'cast_spaces'                        => true,
+    ])
+    ->setFinder($finder)
+    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');

--- a/admin/controller/extension/captcha/basic.php
+++ b/admin/controller/extension/captcha/basic.php
@@ -1,67 +1,71 @@
 <?php
-class ControllerExtensionCaptchaBasic extends Controller {
-	private $error = array();
 
-	public function index() {
-		$this->load->language('extension/captcha/basic');
+class ControllerExtensionCaptchaBasic extends Controller
+{
+    private $error = [];
 
-		$this->document->setTitle($this->language->get('heading_title'));
+    public function index()
+    {
+        $this->load->language('extension/captcha/basic');
 
-		$this->load->model('setting/setting');
+        $this->document->setTitle($this->language->get('heading_title'));
 
-		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
-			$this->model_setting_setting->editSetting('captcha_basic', $this->request->post);
+        $this->load->model('setting/setting');
 
-			$this->session->data['success'] = $this->language->get('text_success');
+        if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
+            $this->model_setting_setting->editSetting('captcha_basic', $this->request->post);
 
-			$this->response->redirect($this->url->link('extension/extension', 'user_token=' . $this->session->data['user_token'] . '&type=captcha', true));
-		}
+            $this->session->data['success'] = $this->language->get('text_success');
 
-		if (isset($this->error['warning'])) {
-			$data['error_warning'] = $this->error['warning'];
-		} else {
-			$data['error_warning'] = '';
-		}
+            $this->response->redirect($this->url->link('extension/extension', 'user_token=' . $this->session->data['user_token'] . '&type=captcha', true));
+        }
 
-		$data['breadcrumbs'] = array();
+        if (isset($this->error['warning'])) {
+            $data['error_warning'] = $this->error['warning'];
+        } else {
+            $data['error_warning'] = '';
+        }
 
-		$data['breadcrumbs'][] = array(
-			'text' => $this->language->get('text_home'),
-			'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'], true)
-		);
+        $data['breadcrumbs'] = [];
 
-		$data['breadcrumbs'][] = array(
-			'text' => $this->language->get('text_extension'),
-			'href' => $this->url->link('extension/extension', 'user_token=' . $this->session->data['user_token'] . '&type=captcha', true)
-		);
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'], true),
+        ];
 
-		$data['breadcrumbs'][] = array(
-			'text' => $this->language->get('heading_title'),
-			'href' => $this->url->link('extension/captcha/basic', 'user_token=' . $this->session->data['user_token'], true)
-		);
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('text_extension'),
+            'href' => $this->url->link('extension/extension', 'user_token=' . $this->session->data['user_token'] . '&type=captcha', true),
+        ];
 
-		$data['action'] = $this->url->link('extension/captcha/basic', 'user_token=' . $this->session->data['user_token'], true);
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('heading_title'),
+            'href' => $this->url->link('extension/captcha/basic', 'user_token=' . $this->session->data['user_token'], true),
+        ];
 
-		$data['cancel'] = $this->url->link('extension/extension', 'user_token=' . $this->session->data['user_token'] . '&type=captcha', true);
+        $data['action'] = $this->url->link('extension/captcha/basic', 'user_token=' . $this->session->data['user_token'], true);
 
-		if (isset($this->request->post['captcha_basic_status'])) {
-			$data['captcha_basic_status'] = $this->request->post['captcha_basic_status'];
-		} else {
-			$data['captcha_basic_status'] = $this->config->get('captcha_basic_status');
-		}
+        $data['cancel'] = $this->url->link('extension/extension', 'user_token=' . $this->session->data['user_token'] . '&type=captcha', true);
 
-		$data['header'] = $this->load->controller('common/header');
-		$data['column_left'] = $this->load->controller('common/column_left');
-		$data['footer'] = $this->load->controller('common/footer');
+        if (isset($this->request->post['captcha_basic_status'])) {
+            $data['captcha_basic_status'] = $this->request->post['captcha_basic_status'];
+        } else {
+            $data['captcha_basic_status'] = $this->config->get('captcha_basic_status');
+        }
 
-		$this->response->setOutput($this->load->view('extension/captcha/basic', $data));
-	}
+        $data['header'] = $this->load->controller('common/header');
+        $data['column_left'] = $this->load->controller('common/column_left');
+        $data['footer'] = $this->load->controller('common/footer');
 
-	protected function validate() {
-		if (!$this->user->hasPermission('modify', 'extension/captcha/basic')) {
-			$this->error['warning'] = $this->language->get('error_permission');
-		}
+        $this->response->setOutput($this->load->view('extension/captcha/basic', $data));
+    }
 
-		return !$this->error;
-	}
+    protected function validate()
+    {
+        if (!$this->user->hasPermission('modify', 'extension/captcha/basic')) {
+            $this->error['warning'] = $this->language->get('error_permission');
+        }
+
+        return !$this->error;
+    }
 }

--- a/admin/controller/extension/captcha/google.php
+++ b/admin/controller/extension/captcha/google.php
@@ -1,108 +1,114 @@
 <?php
-class ControllerExtensionCaptchaGoogle extends Controller {
-	private $error = array();
 
-    public function index() {
-		$data = $this->load->language('extension/captcha/google');
+class ControllerExtensionCaptchaGoogle extends Controller
+{
+    private $error = [];
 
-		$this->document->setTitle($this->language->get('heading_title'));
+    public function index()
+    {
+        $data = $this->load->language('extension/captcha/google');
 
-		$this->load->model('setting/setting');
+        $this->document->setTitle($this->language->get('heading_title'));
 
-		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
-			$this->model_setting_setting->editSetting('captcha_google', $this->request->post);
+        $this->load->model('setting/setting');
 
-			$this->session->data['success'] = $this->language->get('text_success');
+        if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
+            $this->model_setting_setting->editSetting('captcha_google', $this->request->post);
 
-			$this->response->redirect($this->url->link('extension/extension', 'token=' . $this->session->data['token'] . '&type=captcha', true));
-		}
+            $this->session->data['success'] = $this->language->get('text_success');
 
-		if (isset($this->error['warning'])) {
-			$data['error_warning'] = $this->error['warning'];
-		} else {
-			$data['error_warning'] = '';
-		}
+            $this->response->redirect($this->url->link('extension/extension', 'token=' . $this->session->data['token'] . '&type=captcha', true));
+        }
 
-		if (isset($this->error['key'])) {
-			$data['error_key'] = $this->error['key'];
-		} else {
-			$data['error_key'] = '';
-		}
+        if (isset($this->error['warning'])) {
+            $data['error_warning'] = $this->error['warning'];
+        } else {
+            $data['error_warning'] = '';
+        }
 
-		if (isset($this->error['secret'])) {
-			$data['error_secret'] = $this->error['secret'];
-		} else {
-			$data['error_secret'] = '';
-		}
+        if (isset($this->error['key'])) {
+            $data['error_key'] = $this->error['key'];
+        } else {
+            $data['error_key'] = '';
+        }
 
-		$data['breadcrumbs'] = array();
+        if (isset($this->error['secret'])) {
+            $data['error_secret'] = $this->error['secret'];
+        } else {
+            $data['error_secret'] = '';
+        }
 
-		$data['breadcrumbs'][] = array(
-			'text' => $this->language->get('text_home'),
-			'href' => $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], true)
-		);
+        $data['breadcrumbs'] = [];
 
-		$data['breadcrumbs'][] = array(
-			'text' => $this->language->get('text_extension'),
-			'href' => $this->url->link('extension/extension', 'token=' . $this->session->data['token'] . '&type=captcha', true)
-		);
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], true),
+        ];
 
-		$data['breadcrumbs'][] = array(
-			'text' => $this->language->get('heading_title'),
-			'href' => $this->url->link('extension/captcha/google', 'token=' . $this->session->data['token'], true)
-		);
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('text_extension'),
+            'href' => $this->url->link('extension/extension', 'token=' . $this->session->data['token'] . '&type=captcha', true),
+        ];
 
-		$data['action'] = $this->url->link('extension/captcha/google', 'token=' . $this->session->data['token'], true);
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('heading_title'),
+            'href' => $this->url->link('extension/captcha/google', 'token=' . $this->session->data['token'], true),
+        ];
 
-		$data['cancel'] = $this->url->link('extension/extension', 'token=' . $this->session->data['token'] . '&type=captcha', true);
+        $data['action'] = $this->url->link('extension/captcha/google', 'token=' . $this->session->data['token'], true);
 
-		if (isset($this->request->post['captcha_google_key'])) {
-			$data['captcha_google_key'] = $this->request->post['captcha_google_key'];
-		} else {
-			$data['captcha_google_key'] = $this->config->get('captcha_google_key');
-		}
+        $data['cancel'] = $this->url->link('extension/extension', 'token=' . $this->session->data['token'] . '&type=captcha', true);
 
-		if (isset($this->request->post['captcha_google_secret'])) {
-			$data['captcha_google_secret'] = $this->request->post['captcha_google_secret'];
-		} else {
-			$data['captcha_google_secret'] = $this->config->get('captcha_google_secret');
-		}
+        if (isset($this->request->post['captcha_google_key'])) {
+            $data['captcha_google_key'] = $this->request->post['captcha_google_key'];
+        } else {
+            $data['captcha_google_key'] = $this->config->get('captcha_google_key');
+        }
 
-		if (isset($this->request->post['captcha_google_status'])) {
-			$data['captcha_google_status'] = $this->request->post['captcha_google_status'];
-		} else {
-			$data['captcha_google_status'] = $this->config->get('captcha_google_status');
-		}
+        if (isset($this->request->post['captcha_google_secret'])) {
+            $data['captcha_google_secret'] = $this->request->post['captcha_google_secret'];
+        } else {
+            $data['captcha_google_secret'] = $this->config->get('captcha_google_secret');
+        }
 
-		$data['header'] = $this->load->controller('common/header');
-		$data['column_left'] = $this->load->controller('common/column_left');
-		$data['footer'] = $this->load->controller('common/footer');
+        if (isset($this->request->post['captcha_google_status'])) {
+            $data['captcha_google_status'] = $this->request->post['captcha_google_status'];
+        } else {
+            $data['captcha_google_status'] = $this->config->get('captcha_google_status');
+        }
 
-		$this->response->setOutput($this->load->view('extension/captcha/google', $data));
-	}
-    public function install() {
+        $data['header'] = $this->load->controller('common/header');
+        $data['column_left'] = $this->load->controller('common/column_left');
+        $data['footer'] = $this->load->controller('common/footer');
+
+        $this->response->setOutput($this->load->view('extension/captcha/google', $data));
+    }
+    public function install()
+    {
         // TODO: required for installation, fatal error otherwise.
         return;
     }
 
-    public function uninstall() {
+    public function uninstall()
+    {
         // TODO: required for installation, fatal error otherwise.
         return;
     }
 
-	protected function validate() {
-		if (!$this->user->hasPermission('modify', 'extension/captcha/google')) {
-			$this->error['warning'] = $this->language->get('error_permission');
-		}
+    protected function validate()
+    {
+        if (!$this->user->hasPermission('modify', 'extension/captcha/google')) {
+            $this->error['warning'] = $this->language->get('error_permission');
+        }
 
-		if (empty($this->request->post['captcha_google_key'])) {
-			$this->error['key'] = $this->language->get('error_key');
-		}
+        if (empty($this->request->post['captcha_google_key'])) {
+            $this->error['key'] = $this->language->get('error_key');
+        }
 
-		if (empty($this->request->post['captcha_google_secret'])) {
-			$this->error['secret'] = $this->language->get('error_secret');
-		}
+        if (empty($this->request->post['captcha_google_secret'])) {
+            $this->error['secret'] = $this->language->get('error_secret');
+        }
 
-		return !$this->error;
-	}
+        return !$this->error;
+    }
 }

--- a/admin/controller/extension/extension/captcha.php
+++ b/admin/controller/extension/extension/captcha.php
@@ -1,119 +1,125 @@
 <?php
-class ControllerExtensionExtensionCaptcha extends Controller {
-	private $error = array();
 
-	public function index() {
-		$this->load->language('extension/extension/captcha');
+class ControllerExtensionExtensionCaptcha extends Controller
+{
+    private $error = [];
 
-		$this->load->model('setting/extension');
+    public function index()
+    {
+        $this->load->language('extension/extension/captcha');
 
-		$this->getList();
-	}
+        $this->load->model('setting/extension');
 
-	public function install() {
-		$this->load->language('extension/extension/captcha');
+        $this->getList();
+    }
 
-		$this->load->model('setting/extension');
+    public function install()
+    {
+        $this->load->language('extension/extension/captcha');
 
-		if ($this->validate()) {
-			$this->model_setting_extension->install('captcha', $this->request->get['extension']);
+        $this->load->model('setting/extension');
 
-			$this->load->model('user/user_group');
+        if ($this->validate()) {
+            $this->model_setting_extension->install('captcha', $this->request->get['extension']);
 
-			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'extension/captcha/' . $this->request->get['extension']);
-			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'extension/captcha/' . $this->request->get['extension']);
+            $this->load->model('user/user_group');
 
-			// Compatibility
-			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'captcha/' . $this->request->get['extension']);
-			$this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'captcha/' . $this->request->get['extension']);
+            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'extension/captcha/' . $this->request->get['extension']);
+            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'extension/captcha/' . $this->request->get['extension']);
 
-			// Call install method if it exsits
-			$this->load->controller('extension/captcha/' . $this->request->get['extension'] . '/install');
+            // Compatibility
+            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'access', 'captcha/' . $this->request->get['extension']);
+            $this->model_user_user_group->addPermission($this->user->getGroupId(), 'modify', 'captcha/' . $this->request->get['extension']);
 
-			$this->session->data['success'] = $this->language->get('text_success');
-		}
+            // Call install method if it exsits
+            $this->load->controller('extension/captcha/' . $this->request->get['extension'] . '/install');
 
-		$this->getList();
-	}
+            $this->session->data['success'] = $this->language->get('text_success');
+        }
 
-	public function uninstall() {
-		$this->load->language('extension/extension/captcha');
+        $this->getList();
+    }
 
-		$this->load->model('setting/extension');
+    public function uninstall()
+    {
+        $this->load->language('extension/extension/captcha');
 
-		if ($this->validate()) {
-			$this->model_setting_extension->uninstall('captcha', $this->request->get['extension']);
+        $this->load->model('setting/extension');
 
-			// Call uninstall method if it exsits
-			$this->load->controller('extension/captcha/' . $this->request->get['extension'] . '/uninstall');
+        if ($this->validate()) {
+            $this->model_setting_extension->uninstall('captcha', $this->request->get['extension']);
 
-			$this->session->data['success'] = $this->language->get('text_success');
-		}
+            // Call uninstall method if it exsits
+            $this->load->controller('extension/captcha/' . $this->request->get['extension'] . '/uninstall');
 
-		$this->getList();
-	}
+            $this->session->data['success'] = $this->language->get('text_success');
+        }
 
-	protected function getList() {
+        $this->getList();
+    }
+
+    protected function getList()
+    {
         $data = $this->load->language('extension/captcha');
 
-		if (isset($this->error['warning'])) {
-			$data['error_warning'] = $this->error['warning'];
-		} else {
-			$data['error_warning'] = '';
-		}
+        if (isset($this->error['warning'])) {
+            $data['error_warning'] = $this->error['warning'];
+        } else {
+            $data['error_warning'] = '';
+        }
 
-		if (isset($this->session->data['success'])) {
-			$data['success'] = $this->session->data['success'];
+        if (isset($this->session->data['success'])) {
+            $data['success'] = $this->session->data['success'];
 
-			unset($this->session->data['success']);
-		} else {
-			$data['success'] = '';
-		}
+            unset($this->session->data['success']);
+        } else {
+            $data['success'] = '';
+        }
 
-		$extensions = $this->model_setting_extension->getInstalled('captcha');
+        $extensions = $this->model_setting_extension->getInstalled('captcha');
 
+        foreach ($extensions as $key => $value) {
+            if (!is_file(DIR_APPLICATION . 'controller/extension/captcha/' . $value . '.php') && !is_file(DIR_APPLICATION . 'controller/captcha/' . $value . '.php')) {
+                $this->model_setting_extension->uninstall('captcha', $value);
 
-		foreach ($extensions as $key => $value) {
-			if (!is_file(DIR_APPLICATION . 'controller/extension/captcha/' . $value . '.php') && !is_file(DIR_APPLICATION . 'controller/captcha/' . $value . '.php')) {
-				$this->model_setting_extension->uninstall('captcha', $value);
+                unset($extensions[$key]);
+            }
+        }
 
-				unset($extensions[$key]);
-			}
-		}
+        $data['extensions'] = [];
 
-		$data['extensions'] = array();
+        // Compatibility code for old extension folders
+        $files = glob(DIR_APPLICATION . 'controller/extension/captcha/*.php');
 
-		// Compatibility code for old extension folders
-		$files = glob(DIR_APPLICATION . 'controller/extension/captcha/*.php');
-
-		if ($files) {
-			foreach ($files as $file) {
-				$extension = basename($file, '.php');
+        if ($files) {
+            foreach ($files as $file) {
+                $extension = basename($file, '.php');
 
                 $this->load->language('extension/captcha/' . $extension);
 
-				$data['extensions'][] = array(
-					'name'      => $this->language->get('heading_title') ? $this->language->get('heading_title') : $extension . (($extension == $this->config->get('config_captcha')) ? $this->language->get('text_default') : null),
-					'status'    => $this->config->get('captcha_' . $extension . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled'),
-                    'module'    => [],
+                $data['extensions'][] = [
+                    'name' => $this->language->get('heading_title') ? $this->language->get('heading_title') : $extension . (($extension == $this->config->get('config_captcha')) ? $this->language->get('text_default') : null),
+                    'status' => $this->config->get('captcha_' . $extension . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled'),
+                    'module' => [],
                     'extension' => $extension,
-					'install'   => $this->url->link('extension/extension/captcha/install', 'token=' . $this->session->data['token'] . '&extension=' . $extension, true),
-					'uninstall' => $this->url->link('extension/extension/captcha/uninstall', 'token=' . $this->session->data['token'] . '&extension=' . $extension, true),
-					'installed' => in_array($extension, $extensions),
-					'edit'      => $this->url->link('extension/captcha/' . $extension, 'token=' . $this->session->data['token'], true)
-				);
+                    'install' => $this->url->link('extension/extension/captcha/install', 'token=' . $this->session->data['token'] . '&extension=' . $extension, true),
+                    'uninstall' => $this->url->link('extension/extension/captcha/uninstall', 'token=' . $this->session->data['token'] . '&extension=' . $extension, true),
+                    'installed' => in_array($extension, $extensions),
+                    'edit' => $this->url->link('extension/captcha/' . $extension, 'token=' . $this->session->data['token'], true),
+                ];
                 $this->language->set('heading_title', '');
-			}
-		}
+            }
+        }
 
-		$this->response->setOutput($this->load->view('extension/extension/captcha', $data));
-	}
+        $this->response->setOutput($this->load->view('extension/extension/captcha', $data));
+    }
 
-	protected function validate() {
-		if (!$this->user->hasPermission('modify', 'extension/extension/captcha')) {
-			$this->error['warning'] = $this->language->get('error_permission');
-		}
+    protected function validate()
+    {
+        if (!$this->user->hasPermission('modify', 'extension/extension/captcha')) {
+            $this->error['warning'] = $this->language->get('error_permission');
+        }
 
-		return !$this->error;
-	}
+        return !$this->error;
+    }
 }

--- a/admin/controller/extension/extension/menu.php
+++ b/admin/controller/extension/extension/menu.php
@@ -1,8 +1,11 @@
 <?php
-class ControllerExtensionExtensionMenu extends Controller {
-    private $error = array();
 
-    public function index() {
+class ControllerExtensionExtensionMenu extends Controller
+{
+    private $error = [];
+
+    public function index()
+    {
         $this->load->language('extension/extension/menu');
 
         $this->load->model('setting/extension');
@@ -10,7 +13,8 @@ class ControllerExtensionExtensionMenu extends Controller {
         $this->getList();
     }
 
-    public function install() {
+    public function install()
+    {
         $this->load->language('extension/extension/menu');
 
         $this->load->model('setting/extension');
@@ -32,7 +36,8 @@ class ControllerExtensionExtensionMenu extends Controller {
         $this->getList();
     }
 
-    public function uninstall() {
+    public function uninstall()
+    {
         $this->load->language('extension/extension/menu');
 
         $this->load->model('setting/extension');
@@ -49,10 +54,10 @@ class ControllerExtensionExtensionMenu extends Controller {
         $this->getList();
     }
 
-    protected function getList() {
+    protected function getList()
+    {
 
         $data = $this->load->language('extension/extension/menu');
-
 
         $data['text_layout'] = sprintf($this->language->get('text_layout'), $this->url->link('design/layout', 'user_token=' . $this->session->data['token'], true));
 
@@ -80,7 +85,7 @@ class ControllerExtensionExtensionMenu extends Controller {
             }
         }
 
-        $data['extensions'] = array();
+        $data['extensions'] = [];
 
         // Compatibility code for old extension folders
         $files = glob(DIR_APPLICATION . 'controller/extension/menu/*.php');
@@ -91,21 +96,21 @@ class ControllerExtensionExtensionMenu extends Controller {
 
                 $this->load->language('extension/menu/' . $extension, 'extension');
 
-                $data['extensions'][] = array(
-                    'name'      => $this->language->get('heading_title') ? $this->language->get('heading_title') : $extension,
-                    'status'    => $this->config->get('menu_' . $extension . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled'),
-                    'module'    => [],
+                $data['extensions'][] = [
+                    'name' => $this->language->get('heading_title') ? $this->language->get('heading_title') : $extension,
+                    'status' => $this->config->get('menu_' . $extension . '_status') ? $this->language->get('text_enabled') : $this->language->get('text_disabled'),
+                    'module' => [],
                     'extension' => $extension,
-                    'install'   => $this->url->link('extension/extension/menu/install', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
+                    'install' => $this->url->link('extension/extension/menu/install', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
                     'uninstall' => $this->url->link('extension/extension/menu/uninstall', 'user_token=' . $this->session->data['user_token'] . '&extension=' . $extension, true),
                     'installed' => in_array($extension, $extensions),
-                    'edit'      => $this->url->link('extension/menu/' . $extension, 'user_token=' . $this->session->data['user_token'], true)
-                );
+                    'edit' => $this->url->link('extension/menu/' . $extension, 'user_token=' . $this->session->data['user_token'], true),
+                ];
                 $this->language->set('heading_title', '');
             }
         }
 
-        $sort_order = array();
+        $sort_order = [];
 
         foreach ($data['extensions'] as $key => $value) {
             $sort_order[$key] = $value['name'];
@@ -116,7 +121,8 @@ class ControllerExtensionExtensionMenu extends Controller {
         $this->response->setOutput($this->load->view('extension/extension/menu', $data));
     }
 
-    protected function validate() {
+    protected function validate()
+    {
         if (!$this->user->hasPermission('modify', 'extension/extension/menu')) {
             $this->error['warning'] = $this->language->get('error_permission');
         }

--- a/admin/controller/extension/shipping/location_based_shipping.php
+++ b/admin/controller/extension/shipping/location_based_shipping.php
@@ -1,8 +1,11 @@
 <?php
-class ControllerExtensionShippingLocationBasedShipping extends Controller {
+
+class ControllerExtensionShippingLocationBasedShipping extends Controller
+{
     private $error;
 
-    public function index() {
+    public function index()
+    {
 
         $data = $this->load->language('extension/shipping/location_based_shipping');
 
@@ -12,15 +15,15 @@ class ControllerExtensionShippingLocationBasedShipping extends Controller {
 
         if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
 
-            $costs = array();
+            $costs = [];
             foreach ($this->request->post['location_based_shipping_cost'] as $cost) {
                 $costs[$cost['group']][] = $cost;
             }
-            $postData = array(
-                'location_based_shipping_status'     => $this->request->post['location_based_shipping_status'],
+            $postData = [
+                'location_based_shipping_status' => $this->request->post['location_based_shipping_status'],
                 'location_based_shipping_sort_order' => $this->request->post['location_based_shipping_sort_order'],
-                'location_based_shipping_cost'       => $costs,
-            );
+                'location_based_shipping_cost' => $costs,
+            ];
 
             $this->model_setting_setting->editSetting('location_based_shipping', $postData);
 
@@ -48,27 +51,27 @@ class ControllerExtensionShippingLocationBasedShipping extends Controller {
         $data['geo_zones'] = $this->model_localisation_geo_zone->getGeoZones();
         $data['tax_classes'] = $this->model_localisation_tax_class->getTaxClasses();
 
-        $data['breadcrumbs'] = array();
-        $data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('text_home'),
-            'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => false
-        );
+        $data['breadcrumbs'] = [];
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+            'separator' => false,
+        ];
 
-        $data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('text_shipping'),
-            'href'      => $this->url->link('extension/shipping', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => ' :: '
-        );
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('text_shipping'),
+            'href' => $this->url->link('extension/shipping', 'token=' . $this->session->data['token'], 'SSL'),
+            'separator' => ' :: ',
+        ];
 
-        $data['breadcrumbs'][] = array(
-            'text'      => $this->language->get('heading_title'),
-            'href'      => $this->url->link('extension/shipping/location_based_shipping', 'token=' . $this->session->data['token'], 'SSL'),
-            'separator' => ' :: '
-        );
+        $data['breadcrumbs'][] = [
+            'text' => $this->language->get('heading_title'),
+            'href' => $this->url->link('extension/shipping/location_based_shipping', 'token=' . $this->session->data['token'], 'SSL'),
+            'separator' => ' :: ',
+        ];
 
-        $postKeyArray = array( 'location_based_shipping_status', 'location_based_shipping_sort_order',
-            'location_based_shipping_cost' );
+        $postKeyArray = [ 'location_based_shipping_status', 'location_based_shipping_sort_order',
+            'location_based_shipping_cost' ];
         foreach ($postKeyArray as $key) {
             if (isset($this->request->post['location_based_shipping_status'])) {
                 $data[$key] = $this->request->post[$key];
@@ -84,7 +87,8 @@ class ControllerExtensionShippingLocationBasedShipping extends Controller {
         $this->response->setOutput($this->load->view('extension/shipping/location_based_shipping.tpl', $data));
     }
 
-    protected function validate() {
+    protected function validate()
+    {
         if (!$this->user->hasPermission('modify', 'extension/shipping/location_based_shipping')) {
             $this->error['warning'] = $this->language->get('error_permission');
         }
@@ -96,12 +100,14 @@ class ControllerExtensionShippingLocationBasedShipping extends Controller {
         }
     }
 
-    public function install() {
+    public function install()
+    {
         // bulk OC3 design install function
         return 0;
     }
 
-    public function uninstall() {
+    public function uninstall()
+    {
         // bulk OC3 design install function
         return 0;
     }

--- a/admin/controller/user/password.php
+++ b/admin/controller/user/password.php
@@ -1,13 +1,17 @@
 <?php
-class ControllerUserPassword extends Controller {
-    private $error = array();
 
-    public function index() {
+class ControllerUserPassword extends Controller
+{
+    private $error = [];
+
+    public function index()
+    {
         // $data = $this->language->load('user/user');
         $this->getForm();
     }
 
-    public function change() {
+    public function change()
+    {
         if ($this->request->post && $this->validate()) {
 
         } else {
@@ -15,7 +19,8 @@ class ControllerUserPassword extends Controller {
         }
     }
 
-    protected function getForm() {
+    protected function getForm()
+    {
         $data = $this->language->load('user/user');
 
         $this->document->setTitle($this->language->get('heading_title'));
@@ -27,17 +32,18 @@ class ControllerUserPassword extends Controller {
         $data['header'] = $this->load->controller('common/header');
         $data['column_left'] = $this->load->controller('common/column_left');
         $data['footer'] = $this->load->controller('common/footer');
-        $data['breadcrumbs'] = array();
+        $data['breadcrumbs'] = [];
         $this->response->setOutput($this->load->view('user/password', $data));
     }
 
-    protected function validate() {
+    protected function validate()
+    {
         if ($this->request->post['new_password'] != $this->request->post['new_password_confirm']) {
             $this->error['error_confirm'] = 'Paroles nav vienādas!';
         }
 
-        $user_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "user WHERE "
-            . "user_id = '" . (int)$this->session->data['user_id'] . "' AND status = '1' limit 1");
+        $user_query = $this->db->query('SELECT * FROM ' . DB_PREFIX . 'user WHERE '
+            . "user_id = '" . (int) $this->session->data['user_id'] . "' AND status = '1' limit 1");
 
         if (!$user_query->num_rows) {
             return false;
@@ -49,7 +55,7 @@ class ControllerUserPassword extends Controller {
         }
 
         // Update password
-        $password_update = $this->db->query("UPDATE " . DB_PREFIX . "user "
+        $password_update = $this->db->query('UPDATE ' . DB_PREFIX . 'user '
             . "SET password = '" . password_hash($this->request->post['new_password'], PASSWORD_DEFAULT) . "' "
             . "WHERE user_id = '" . $this->session->data['user_id'] . "'");
 
@@ -57,4 +63,3 @@ class ControllerUserPassword extends Controller {
     }
 
 }
-?>

--- a/admin/language/en-gb/extension/captcha/basic.php
+++ b/admin/language/en-gb/extension/captcha/basic.php
@@ -1,14 +1,15 @@
 <?php
+
 // Heading
-$_['heading_title']    = 'Basic Captcha';
+$_['heading_title'] = 'Basic Captcha';
 
 // Text
-$_['text_extension']   = 'Extensions';
-$_['text_success']     = 'Success: You have modified Basic Captcha!';
-$_['text_edit']        = 'Edit Basic Captcha';
+$_['text_extension'] = 'Extensions';
+$_['text_success'] = 'Success: You have modified Basic Captcha!';
+$_['text_edit'] = 'Edit Basic Captcha';
 
 // Entry
-$_['entry_status']     = 'Status';
+$_['entry_status'] = 'Status';
 
 // Error
 $_['error_permission'] = 'Warning: You do not have permission to modify Basic Captcha!';

--- a/admin/language/en-gb/extension/captcha/google.php
+++ b/admin/language/en-gb/extension/captcha/google.php
@@ -1,19 +1,20 @@
 <?php
+
 // Heading
-$_['heading_title']    = 'Google reCAPTCHA';
+$_['heading_title'] = 'Google reCAPTCHA';
 
 // Text
-$_['text_extension']   = 'Extensions';
-$_['text_success']     = 'Success: You have modified Google reCAPTCHA!';
-$_['text_edit']        = 'Edit Google reCAPTCHA';
-$_['text_signup']      = 'Go to <a href="https://www.google.com/recaptcha/intro/index.html" target="_blank"><u>Google reCAPTCHA page</u></a> and register your website.';
+$_['text_extension'] = 'Extensions';
+$_['text_success'] = 'Success: You have modified Google reCAPTCHA!';
+$_['text_edit'] = 'Edit Google reCAPTCHA';
+$_['text_signup'] = 'Go to <a href="https://www.google.com/recaptcha/intro/index.html" target="_blank"><u>Google reCAPTCHA page</u></a> and register your website.';
 
 // Entry
-$_['entry_key']        = 'Site key';
-$_['entry_secret']     = 'Secret key';
-$_['entry_status']     = 'Status';
+$_['entry_key'] = 'Site key';
+$_['entry_secret'] = 'Secret key';
+$_['entry_status'] = 'Status';
 
 // Error
 $_['error_permission'] = 'Warning: You do not have permission to modify Google reCAPTCHA!';
-$_['error_key']        = 'Key required!';
-$_['error_secret']     = 'Secret required!';
+$_['error_key'] = 'Key required!';
+$_['error_secret'] = 'Secret required!';

--- a/admin/language/en-gb/extension/module/categoryfeatured.php
+++ b/admin/language/en-gb/extension/module/categoryfeatured.php
@@ -1,4 +1,5 @@
 <?php
+
 // Heading
 $_['heading_title'] = 'Category Featured';
 

--- a/admin/language/en-gb/extension/module/sms_alert.php
+++ b/admin/language/en-gb/extension/module/sms_alert.php
@@ -1,4 +1,5 @@
 <?php
+
 // Heading
 $_['heading_title'] = 'Оповещение по SMS &copy; <a href="http://opencart-russia.ru/">opencart-russia.ru</a>';
 $_['heading_title1'] = 'Оповещение по SMS &copy;  opencart-russia.ru';
@@ -12,7 +13,6 @@ $_['text_edit'] = 'Настройки модуля';
 $_['entry_sms_alert_tel'] = 'Номер телефона для оповещения о заказе';
 $_['entry_sms_alert_id'] = 'Ваш API_ID';
 $_['entry_processing_status'] = 'Статусы заказа для оповещения';
-
 
 $_['entry_status'] = 'Статус';
 
@@ -29,8 +29,3 @@ $_['error_permission'] = 'У Вас нет прав для управления 
 $_['error_sms_alert_tel'] = 'Необходим телефон для оповещения';
 $_['error_sms_alert_id'] = 'Необходим ваш API_ID из личного кабинета';
 $_['error_sms_alert_processing_status'] = 'Необходимо выбрать статус заказа для оповещения';
-
-
-
-
-

--- a/admin/language/en-gb/extension/shipping/location_based_shipping.php
+++ b/admin/language/en-gb/extension/shipping/location_based_shipping.php
@@ -1,4 +1,5 @@
 <?php
+
 // Heading
 $_['heading_title'] = 'Location Based Shipping';
 
@@ -24,10 +25,8 @@ $_['error_permission'] = 'Warning: You do not have permission to modify Location
 $_['text_rates'] = 'Rates';
 $_['text_rates_info'] = 'Rates info';
 
-
 $_['text_cost'] = 'Costs';
 $_['text_cost_info'] = 'Costs info';
-
 
 $_['entry_title'] = 'Title';
 $_['entry_show_address'] = 'Rādīt adresi?';

--- a/admin/model/extension/cr_translate_mate.php
+++ b/admin/model/extension/cr_translate_mate.php
@@ -1,22 +1,27 @@
 <?php
+
 /**
  * Class ModelModuleCrTranslateMate
  *
  * Used to retrieve and save translations
  */
-class ModelExtensionCrTranslateMate extends Model {
+class ModelExtensionCrTranslateMate extends Model
+{
     protected $model; // instance of the model - used to avoid OpenCart's proxy system
 
-    public function __construct($registry) {
+    public function __construct($registry)
+    {
         $this->model = new CrTranslateMateModel($registry);
         parent::__construct($registry);
     }
 
-    public function install() {
+    public function install()
+    {
         $this->model->install();
     }
 
-    public function uninstall() {
+    public function uninstall()
+    {
         $this->model->uninstall();
     }
 
@@ -25,7 +30,8 @@ class ModelExtensionCrTranslateMate extends Model {
      *
      * @return CrTranslateMateModel
      */
-    public function getInstance() {
+    public function getInstance()
+    {
         return $this->model;
     }
 
@@ -38,10 +44,11 @@ class ModelExtensionCrTranslateMate extends Model {
  * a custom model outside the official model class above. The Translate Mate controller will ask for an
  * instance of this class instead of using OpenCart's proxied version.
  */
-class CrTranslateMateModel extends model {
+class CrTranslateMateModel extends model
+{
     protected $modName = 'cr_translate_mate';
-    protected $dirs = array();
-    protected $langs = array();
+    protected $dirs = [];
+    protected $langs = [];
     protected $basePath = ''; // base path of the application
     protected $adminPath = ''; // relative path to the admin folder
     protected $catalogPath = ''; // relative path to the catalog folder
@@ -49,45 +56,51 @@ class CrTranslateMateModel extends model {
     protected $mainLangFileStr = ''; // the localized string that will represent the main language file
     protected $lastLoadedFile = ''; // the name of the last loaded file
 
-    public function __construct($registry) {
+    public function __construct($registry)
+    {
         $this->basePath = str_replace('/system', '', DIR_SYSTEM);
         $this->adminPath = str_replace($this->basePath, '', DIR_APPLICATION);
         $this->catalogPath = str_replace($this->basePath, '', DIR_CATALOG);
-        $this->dirs = array(
-            'admin'   => DIR_LANGUAGE, // location of the admin language directory
+        $this->dirs = [
+            'admin' => DIR_LANGUAGE, // location of the admin language directory
             'catalog' => DIR_CATALOG . 'language/', // catalog language directory
-        );
+        ];
         parent::__construct($registry);
     }
 
-    public function install() {
+    public function install()
+    {
         // Language folder names changed in OpenCart 2.2.0.0, so make sure the language strings for this extension
         // are in the correct directory and remove the directory that isn't needed.
         if (version_compare(VERSION, '2.2.0.0', '<') && file_exists($this->dirs['admin'] . 'en-gb/module/cr_translate_mate.php')) {
             unlink($this->dirs['admin'] . 'en-gb/module/cr_translate_mate.php');
             rmdir($this->dirs['admin'] . 'en-gb/module');
             rmdir($this->dirs['admin'] . 'en-gb');
-        } else if (file_exists($this->dirs['admin'] . 'english/module/cr_translate_mate.php')) {
+        } elseif (file_exists($this->dirs['admin'] . 'english/module/cr_translate_mate.php')) {
             unlink($this->dirs['admin'] . 'english/module/cr_translate_mate.php');
             rmdir($this->dirs['admin'] . 'english/module');
             rmdir($this->dirs['admin'] . 'english');
         }
     }
 
-    public function uninstall() {
+    public function uninstall()
+    {
         // for the moment, no uninstallation action is needed
     }
 
     // update the language file specified in the input
-    public function saveTranslation($input) {
+    public function saveTranslation($input)
+    {
         $filepath = $this->getFilePath($input['dirKey'], $input['page'], $input['lang']);
         // check that we can write to the file if it exists
         if (file_exists($filepath) && !is_writable($filepath)) {
             return sprintf($this->language->get('error_write_permission'), $filepath);
         }
 
-        $_ = array();
-        if (file_exists($filepath)) { include($filepath); } // this should fill $_ with the strings for this file
+        $_ = [];
+        if (file_exists($filepath)) {
+            include($filepath);
+        } // this should fill $_ with the strings for this file
         $_[$input['key']] = $input['translation'];
 
         // create the file content with the updated array of translation strings
@@ -106,24 +119,30 @@ class CrTranslateMateModel extends model {
             foreach (array_filter(glob(dirname($fileDir) . '/*', GLOB_ONLYDIR)) as $dir) {
                 $dirPerms = fileperms($dir);
             }
-            $dirExists = mkdir($fileDir, $dirPerms, TRUE);
+            $dirExists = mkdir($fileDir, $dirPerms, true);
         }
 
         // if writing to the file fails, return an error. Othewise return a success indicator
-        return $dirExists && (file_put_contents($filepath, $fileContents) !== FALSE) ? array(
-            'success' => $_[$input['key']] ) :
+        return $dirExists && (file_put_contents($filepath, $fileContents) !== false) ? [
+            'success' => $_[$input['key']] ] :
             sprintf($this->language->get('error_write_permission'), $filepath);
     }
 
     // get the full file path based on the file name and language
-    protected function getFilePath($dirKey, $file, $lang) {
-        if ($file == $this->mainLangFileKey) { $file = $lang; };
+    protected function getFilePath($dirKey, $file, $lang)
+    {
+        if ($file == $this->mainLangFileKey) {
+            $file = $lang;
+        };
         return $this->dirs[$dirKey] . $lang . '/' . $file . '.php';
     }
 
     // gets arrays of language data from Opencart
-    public function langs() {
-        if (!empty($this->langs)) { return $this->langs; }
+    public function langs()
+    {
+        if (!empty($this->langs)) {
+            return $this->langs;
+        }
         $this->load->model('localisation/language');
         $this->langs = $this->model_localisation_language->getLanguages();
         foreach ($this->langs as $key => $value) {
@@ -134,15 +153,17 @@ class CrTranslateMateModel extends model {
     }
 
     // extracts the language name from the language arrays
-    public function langNames() {
+    public function langNames()
+    {
         return !empty($this->langNames) ? $this->langNames :
             ($this->langNames = array_map(function ($a) {
-            return $a['directory'];
-        }, $this->langs()));
+                return $a['directory'];
+            }, $this->langs()));
     }
 
     // list the filenames of all files in the language directories
-    public function listFiles($dirKey = "catalog") {
+    public function listFiles($dirKey = 'catalog')
+    {
         // get the directory names of all site languages
         $langs = $this->langNames();
 
@@ -177,24 +198,28 @@ class CrTranslateMateModel extends model {
     }
 
     // get the name to use for the main language file for each language (english.php, spanish.php, etc)
-    public function mainLangFileStr() {
-        if (!empty($this->mainLangFileStr)) { return $this->mainLangFileStr; }
+    public function mainLangFileStr()
+    {
+        if (!empty($this->mainLangFileStr)) {
+            return $this->mainLangFileStr;
+        }
         $this->load->language('module/' . $this->modName);
 
         return $this->mainLangFileStr = h($this->language->get('text_main_lang_file'));
     }
 
     // load all the texts from the selected files with the selected options
-    public function loadTexts(array $options = array()) {
-        $opts = array( // option defaults
-            'length'        => 20, // we'll parse files until we've hit this number. Then we'll stop.
+    public function loadTexts(array $options = [])
+    {
+        $opts = [ // option defaults
+            'length' => 20, // we'll parse files until we've hit this number. Then we'll stop.
             'notTranslated' => false, // get only strings that aren't translated if true
-            'dirKey'        => 'catalog', // whether to fetch admin or catalog strings
-            'singleFile'    => false, // the name of a single file to load (or load all files if false)
-            'keyFilter'     => false, // name of the key to filter by (or no filter if false)
-            'textFilter'    => false, // text to filter by (or no filter if false)
+            'dirKey' => 'catalog', // whether to fetch admin or catalog strings
+            'singleFile' => false, // the name of a single file to load (or load all files if false)
+            'keyFilter' => false, // name of the key to filter by (or no filter if false)
+            'textFilter' => false, // text to filter by (or no filter if false)
             // 'startAfter' => (Start loading texts after this file. ex: account/account)
-        );
+        ];
         // overwrite defaults with given options
         $opts = array_merge($opts, $options);
 
@@ -202,18 +227,17 @@ class CrTranslateMateModel extends model {
 
         //prd($files);
 
-        $texts = array();
+        $texts = [];
         $count = 0;
         $startHere = !isset($opts['startAfter']) && !$opts['singleFile']; // to indicate where to start loading files
 
-
-        foreach($files as $file){ 
-            if($count >= $opts['length']){
+        foreach ($files as $file) {
+            if ($count >= $opts['length']) {
                 break;
             }
             $page = $file;
 
-        //while ($count < $opts['length'] && list($page, $pageStr) = each($files)) {
+            //while ($count < $opts['length'] && list($page, $pageStr) = each($files)) {
             if (!$startHere) { // skip this file if is (or comes before) the file specifed in $opts['startAfter']
                 if (isset($opts['startAfter']) && $page == $opts['startAfter']) {
                     $startHere = true;
@@ -223,18 +247,22 @@ class CrTranslateMateModel extends model {
                     continue;
                 }
             }
-            $pageStrs = array();
+            $pageStrs = [];
 
             foreach ($this->langNames() as $lang) {
                 $path = $this->dirs[$opts['dirKey']] . $lang . '/' . ($page == $this->mainLangFileKey ? $lang : $page) . '.php';
-                if (!file_exists($path)) { continue; }
+                if (!file_exists($path)) {
+                    continue;
+                }
                 // get the language strings (Opencart saves them to the array '$_')
-                $_ = array();
+                $_ = [];
                 include($path);
                 // add the strings to the texts array for the appropriate page and language
                 foreach ($_ as $strKey => $strVal) {
                     // if filtering by key, check if the strKey contains or matches the filter. If not, skip.
-                    if ($opts['keyFilter'] && stripos($strKey, $opts['keyFilter']) === FALSE) { continue; }
+                    if ($opts['keyFilter'] && stripos($strKey, $opts['keyFilter']) === false) {
+                        continue;
+                    }
                     $pageStrs[$strKey][$lang] = $strVal;
                 }
             }
@@ -243,7 +271,7 @@ class CrTranslateMateModel extends model {
                 $pageStrs = $this->notTranslated($pageStrs);
             }
             // filter by text if the option is set
-            if ($opts['textFilter'] !== FALSE) {
+            if ($opts['textFilter'] !== false) {
                 $pageStrs = $this->textFilter($pageStrs, $opts['textFilter'], $page);
             }
 
@@ -256,14 +284,17 @@ class CrTranslateMateModel extends model {
 
             $this->lastLoadedFile = $page; // update the last loaded file
 
-            if ($opts['singleFile']) { break; } // break out of the loop if only loading a single file
+            if ($opts['singleFile']) {
+                break;
+            } // break out of the loop if only loading a single file
         }
 
         return $texts;
     }
 
     // filter out any strings that are fully translated, leaving only those that lack translations
-    protected function notTranslated(array $texts) {
+    protected function notTranslated(array $texts)
+    {
         foreach ($texts as $string => $vals) {
             $translated = true; // assume that the strings are translated until proven otherwise
             foreach ($this->langNames() as $lang) { // check each language
@@ -271,14 +302,17 @@ class CrTranslateMateModel extends model {
                     $translated = false;
                 }
             }
-            if ($translated) { unset($texts[$string]); } // remove string if fully translated
+            if ($translated) {
+                unset($texts[$string]);
+            } // remove string if fully translated
         }
         // if all strings translated, return false, otherwise return the array of untranslated strings
-        return empty($texts) ? array() : $texts;
+        return empty($texts) ? [] : $texts;
     }
 
     // filter out any strings that don't match the given filter (very similar to the notTranslated function)
-    protected function textFilter(array $texts, $filter, $page = '') {
+    protected function textFilter(array $texts, $filter, $page = '')
+    {
         foreach ($texts as $string => $vals) {
             $matches = false; // assume that the strings don't match the filter until proven otherwise
             foreach ($this->langNames() as $lang) { // check each language
@@ -286,21 +320,24 @@ class CrTranslateMateModel extends model {
                     if (!is_string($vals[$lang])) {
                         // log a value for debugging https://github.com/chrisrollins65/cr_translate_mate/issues/2
                         $this->log->write('Translate Mate: searched for [' . $filter . '] and found a non-string on page [' . $page . '] in [' . $string . '->' . $lang . ']: ' . print_r($vals[$lang], true));
-                    } else if (stripos($vals[$lang], $filter) !== FALSE) {
+                    } elseif (stripos($vals[$lang], $filter) !== false) {
                         $matches = true;
                     }
                 }
             }
-            if (!$matches) { unset($texts[$string]); } // remove string if it doesn't match the filter
+            if (!$matches) {
+                unset($texts[$string]);
+            } // remove string if it doesn't match the filter
         }
         // if no strings match, return false, otherwise return the array of the matching strings
         return empty($texts) ? false : $texts;
     }
 
     // turns the list of file paths into a multidimensional array based on path segments
-    public function filesArray($dirKey = "catalog") {
+    public function filesArray($dirKey = 'catalog')
+    {
         $list = $this->listFiles($dirKey);
-        $filesArray = array();
+        $filesArray = [];
         foreach ($list as $key => $file) {
             $this->pathToArray($filesArray, explode('/', $file), $key);
         }
@@ -309,7 +346,8 @@ class CrTranslateMateModel extends model {
     }
 
     // converts a single path into a multidimensional array
-    protected function pathToArray(array &$target, array $parts, $leafValue) {
+    protected function pathToArray(array &$target, array $parts, $leafValue)
+    {
         // get the next segment of the path
         $e = array_shift($parts);
 
@@ -319,14 +357,15 @@ class CrTranslateMateModel extends model {
         }
         // create a new array for this segment if it doesn't exist
         if (!isset($target[$e]) || !is_array($target[$e])) {
-            $target[$e] = array();
+            $target[$e] = [];
         }
         // process the rest of the segments recursively
         $this->pathToArray($target[$e], $parts, $leafValue);
     }
 
     // generates the basic html structure for the files menu
-    public function fileHTMLSelect($dirKey = "catalog") {
+    public function fileHTMLSelect($dirKey = 'catalog')
+    {
         $filesArray = $this->filesArray($dirKey);
 
         $menu = $this->fileHTMLSelectOpts($filesArray);
@@ -335,7 +374,8 @@ class CrTranslateMateModel extends model {
     }
 
     // recursively creates the html structure for each subarray in the $filesArray
-    protected function fileHTMLSelectOpts(array &$filesArray) {
+    protected function fileHTMLSelectOpts(array &$filesArray)
+    {
         $menu = '';
         foreach ($filesArray as $key => $file) {
             if (is_array($file)) {
@@ -348,11 +388,13 @@ class CrTranslateMateModel extends model {
     }
 
     // gets the name of the admin folder (useful if it has been renamed)
-    public function adminPath() {
+    public function adminPath()
+    {
         return $this->adminPath;
     }
 
-    public function getLastLoadedFile() {
+    public function getLastLoadedFile()
+    {
         return $this->lastLoadedFile;
     }
 

--- a/admin/model/setting/extension.php
+++ b/admin/model/setting/extension.php
@@ -1,9 +1,12 @@
 <?php
-class ModelSettingExtension extends Model {
-    public function getInstalled($type) {
-        $extension_data = array();
 
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "extension` WHERE `type` = '" . $this->db->escape($type) . "' ORDER BY `code`");
+class ModelSettingExtension extends Model
+{
+    public function getInstalled($type)
+    {
+        $extension_data = [];
+
+        $query = $this->db->query('SELECT * FROM `' . DB_PREFIX . "extension` WHERE `type` = '" . $this->db->escape($type) . "' ORDER BY `code`");
 
         foreach ($query->rows as $result) {
             $extension_data[] = $result['code'];
@@ -12,20 +15,23 @@ class ModelSettingExtension extends Model {
         return $extension_data;
     }
 
-    public function install($type, $code) {
+    public function install($type, $code)
+    {
         $extensions = $this->getInstalled($type);
 
         if (!in_array($code, $extensions)) {
-            $this->db->query("INSERT INTO `" . DB_PREFIX . "extension` SET `type` = '" . $this->db->escape($type) . "', `code` = '" . $this->db->escape($code) . "'");
+            $this->db->query('INSERT INTO `' . DB_PREFIX . "extension` SET `type` = '" . $this->db->escape($type) . "', `code` = '" . $this->db->escape($code) . "'");
         }
     }
 
-    public function uninstall($type, $code) {
-        $this->db->query("DELETE FROM `" . DB_PREFIX . "extension` WHERE `type` = '" . $this->db->escape($type) . "' AND `code` = '" . $this->db->escape($code) . "'");
-        $this->db->query("DELETE FROM `" . DB_PREFIX . "setting` WHERE `code` = '" . $this->db->escape($type . '_' . $code) . "'");
+    public function uninstall($type, $code)
+    {
+        $this->db->query('DELETE FROM `' . DB_PREFIX . "extension` WHERE `type` = '" . $this->db->escape($type) . "' AND `code` = '" . $this->db->escape($code) . "'");
+        $this->db->query('DELETE FROM `' . DB_PREFIX . "setting` WHERE `code` = '" . $this->db->escape($type . '_' . $code) . "'");
     }
 
-    public function getExtensionInstalls($start = 0, $limit = 10) {
+    public function getExtensionInstalls($start = 0, $limit = 10)
+    {
         if ($start < 0) {
             $start = 0;
         }
@@ -34,33 +40,38 @@ class ModelSettingExtension extends Model {
             $limit = 10;
         }
 
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "extension_install` ORDER BY date_added ASC LIMIT " . (int)$start . "," . (int)$limit);
+        $query = $this->db->query('SELECT * FROM `' . DB_PREFIX . 'extension_install` ORDER BY date_added ASC LIMIT ' . (int) $start . ',' . (int) $limit);
 
         return $query->rows;
     }
 
-    public function getExtensionInstallByExtensionDownloadId($extension_download_id) {
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "extension_install` WHERE `extension_download_id` = '" . (int)$extension_download_id . "'");
+    public function getExtensionInstallByExtensionDownloadId($extension_download_id)
+    {
+        $query = $this->db->query('SELECT * FROM `' . DB_PREFIX . "extension_install` WHERE `extension_download_id` = '" . (int) $extension_download_id . "'");
 
         return $query->row;
     }
 
-    public function getTotalExtensionInstalls() {
-        $query = $this->db->query("SELECT COUNT(*) AS total FROM `" . DB_PREFIX . "extension_install`");
+    public function getTotalExtensionInstalls()
+    {
+        $query = $this->db->query('SELECT COUNT(*) AS total FROM `' . DB_PREFIX . 'extension_install`');
 
         return $query->row['total'];
     }
 
-    public function addExtensionPath($extension_install_id, $path) {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "extension_path` SET `extension_install_id` = '" . (int)$extension_install_id . "', `path` = '" . $this->db->escape($path) . "', `date_added` = NOW()");
+    public function addExtensionPath($extension_install_id, $path)
+    {
+        $this->db->query('INSERT INTO `' . DB_PREFIX . "extension_path` SET `extension_install_id` = '" . (int) $extension_install_id . "', `path` = '" . $this->db->escape($path) . "', `date_added` = NOW()");
     }
 
-    public function deleteExtensionPath($extension_path_id) {
-        $this->db->query("DELETE FROM `" . DB_PREFIX . "extension_path` WHERE `extension_path_id` = '" . (int)$extension_path_id . "'");
+    public function deleteExtensionPath($extension_path_id)
+    {
+        $this->db->query('DELETE FROM `' . DB_PREFIX . "extension_path` WHERE `extension_path_id` = '" . (int) $extension_path_id . "'");
     }
 
-    public function getExtensionPathsByExtensionInstallId($extension_install_id) {
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "extension_path` WHERE `extension_install_id` = '" . (int)$extension_install_id . "' ORDER BY `date_added` ASC");
+    public function getExtensionPathsByExtensionInstallId($extension_install_id)
+    {
+        $query = $this->db->query('SELECT * FROM `' . DB_PREFIX . "extension_path` WHERE `extension_install_id` = '" . (int) $extension_install_id . "' ORDER BY `date_added` ASC");
 
         return $query->rows;
     }

--- a/catalog/controller/checkout/cart.php
+++ b/catalog/controller/checkout/cart.php
@@ -1,8 +1,9 @@
 <?php
 
-class ControllerCheckoutCart extends Controller {
-
-    public function index() {
+class ControllerCheckoutCart extends Controller
+{
+    public function index()
+    {
         $data = $this->load->language('checkout/cart');
 
         $this->document->setTitle($this->language->get('heading_title'));
@@ -75,11 +76,17 @@ class ControllerCheckoutCart extends Controller {
                 }
 
                 if ($product['image']) {
-                    $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}($product['image'], $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
-                        $this->config->get($this->config->get('config_theme') . '_image_cart_height'));
+                    $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}(
+                        $product['image'],
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_height')
+                    );
                 } else {
-                    $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}(Config::get('config_no_image', 'placeholder.png'),
-                        $this->config->get($this->config->get('config_theme') . '_image_cart_width'), $this->config->get($this->config->get('config_theme') . '_image_cart_height'));
+                    $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}(
+                        Config::get('config_no_image', 'placeholder.png'),
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_height')
+                    );
                 }
 
                 $option_data = [];
@@ -98,7 +105,7 @@ class ControllerCheckoutCart extends Controller {
                     }
 
                     $option_data[] = [
-                        'name'  => $option['name'],
+                        'name' => $option['name'],
                         'value' => (utf8_strlen($value) > 20 ? utf8_substr($value, 0, 20) . '..' : $value),
                     ];
                 }
@@ -127,45 +134,66 @@ class ControllerCheckoutCart extends Controller {
 
                 if ($product['recurring']) {
                     $frequencies = [
-                        'day'        => $this->language->get('text_day'),
-                        'week'       => $this->language->get('text_week'),
+                        'day' => $this->language->get('text_day'),
+                        'week' => $this->language->get('text_week'),
                         'semi_month' => $this->language->get('text_semi_month'),
-                        'month'      => $this->language->get('text_month'),
-                        'year'       => $this->language->get('text_year'),
+                        'month' => $this->language->get('text_month'),
+                        'year' => $this->language->get('text_year'),
                     ];
 
                     if ($product['recurring']['trial']) {
-                        $recurring = sprintf($this->language->get('text_trial_description'),
-                                $this->currency->format($this->tax->calculate($product['recurring']['trial_price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
-                                    $this->session->data['currency']), $product['recurring']['trial_cycle'], $frequencies[$product['recurring']['trial_frequency']], $product['recurring']['trial_duration']) . ' ';
+                        $recurring = sprintf(
+                            $this->language->get('text_trial_description'),
+                            $this->currency->format(
+                                $this->tax->calculate($product['recurring']['trial_price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
+                                $this->session->data['currency']
+                            ),
+                            $product['recurring']['trial_cycle'],
+                            $frequencies[$product['recurring']['trial_frequency']],
+                            $product['recurring']['trial_duration']
+                        ) . ' ';
                     }
 
                     if ($product['recurring']['duration']) {
-                        $recurring .= sprintf($this->language->get('text_payment_description'),
-                            $this->currency->format($this->tax->calculate($product['recurring']['price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
-                                $this->session->data['currency']), $product['recurring']['cycle'], $frequencies[$product['recurring']['frequency']], $product['recurring']['duration']);
+                        $recurring .= sprintf(
+                            $this->language->get('text_payment_description'),
+                            $this->currency->format(
+                                $this->tax->calculate($product['recurring']['price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
+                                $this->session->data['currency']
+                            ),
+                            $product['recurring']['cycle'],
+                            $frequencies[$product['recurring']['frequency']],
+                            $product['recurring']['duration']
+                        );
                     } else {
-                        $recurring .= sprintf($this->language->get('text_payment_cancel'),
-                            $this->currency->format($this->tax->calculate($product['recurring']['price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
-                                $this->session->data['currency']), $product['recurring']['cycle'], $frequencies[$product['recurring']['frequency']], $product['recurring']['duration']);
+                        $recurring .= sprintf(
+                            $this->language->get('text_payment_cancel'),
+                            $this->currency->format(
+                                $this->tax->calculate($product['recurring']['price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
+                                $this->session->data['currency']
+                            ),
+                            $product['recurring']['cycle'],
+                            $frequencies[$product['recurring']['frequency']],
+                            $product['recurring']['duration']
+                        );
                     }
                 }
 
                 $data['products'][] = [
-                    'cart_id'      => $product['cart_id'],
-                    'product_id'   => $product['product_id'],
-                    'thumb'        => $image,
-                    'name'         => $product['name'],
-                    'model'        => $product['model'],
-                    'option'       => $option_data,
-                    'recurring'    => $recurring,
+                    'cart_id' => $product['cart_id'],
+                    'product_id' => $product['product_id'],
+                    'thumb' => $image,
+                    'name' => $product['name'],
+                    'model' => $product['model'],
+                    'option' => $option_data,
+                    'recurring' => $recurring,
                     'content_meta' => $product['content_meta'],
-                    'quantity'     => $product['quantity'],
-                    'stock'        => $product['stock'] ? true : !(!$this->config->get('config_stock_checkout') || $this->config->get('config_stock_warning')),
-                    'reward'       => ($product['reward'] ? sprintf($this->language->get('text_points'), $product['reward']) : ''),
-                    'price'        => $price,
-                    'total'        => $total,
-                    'href'         => $this->url->link('product/product', 'product_id=' . $product['product_id']),
+                    'quantity' => $product['quantity'],
+                    'stock' => $product['stock'] ? true : !(!$this->config->get('config_stock_checkout') || $this->config->get('config_stock_warning')),
+                    'reward' => ($product['reward'] ? sprintf($this->language->get('text_points'), $product['reward']) : ''),
+                    'price' => $price,
+                    'total' => $total,
+                    'href' => $this->url->link('product/product', 'product_id=' . $product['product_id']),
                 ];
             }
 
@@ -178,16 +206,15 @@ class ControllerCheckoutCart extends Controller {
             if (!empty($this->session->data['vouchers'])) {
                 foreach ($this->session->data['vouchers'] as $key => $voucher) {
                     $data['vouchers'][] = [
-                        'key'         => $key,
+                        'key' => $key,
                         'description' => $voucher['description'],
-                        'amount'      => $this->currency->format($voucher['amount'], $this->session->data['currency']),
-                        'remove'      => $this->url->link('checkout/cart', 'remove=' . $key),
+                        'amount' => $this->currency->format($voucher['amount'], $this->session->data['currency']),
+                        'remove' => $this->url->link('checkout/cart', 'remove=' . $key),
                     ];
                 }
             }
 
             $data['totals'] = $this->cart->getTotals_azon();
-
 
             $data['continue'] = $this->url->link('common/home');
 
@@ -209,7 +236,6 @@ class ControllerCheckoutCart extends Controller {
                     }
                 }
             }
-
 
             // Needed to redirect, do something with output, if Hook defined!
             if (isset($this->request->post['hook'])) {
@@ -254,13 +280,14 @@ class ControllerCheckoutCart extends Controller {
         }
     }
 
-    public function add() {
+    public function add()
+    {
         $this->load->language('checkout/cart');
 
         $json = [];
 
         if (isset($this->request->post['product_id'])) {
-            $product_id = (int)$this->request->post['product_id'];
+            $product_id = (int) $this->request->post['product_id'];
         } else {
             $product_id = 0;
         }
@@ -270,8 +297,8 @@ class ControllerCheckoutCart extends Controller {
         $product_info = $this->model_catalog_product->getProduct($product_id);
 
         if ($product_info) {
-            if (isset($this->request->post['quantity']) && ((int)$this->request->post['quantity'] >= $product_info['minimum'])) {
-                $quantity = (int)$this->request->post['quantity'];
+            if (isset($this->request->post['quantity']) && ((int) $this->request->post['quantity'] >= $product_info['minimum'])) {
+                $quantity = (int) $this->request->post['quantity'];
             } else {
                 $quantity = $product_info['minimum'] ? $product_info['minimum'] : 1;
             }
@@ -307,31 +334,40 @@ class ControllerCheckoutCart extends Controller {
                 }
 
                 if (!in_array($recurring_id, $recurring_ids)) {
-                    $json['error']['recurring'] = $this->language->get('error_recurring_required'); 
+                    $json['error']['recurring'] = $this->language->get('error_recurring_required');
                 }
             }
             $hook_data = [
                 'quantity' => $quantity,
-                'json'     => $json,
-                'product'  => $product_info,
+                'json' => $json,
+                'product' => $product_info,
             ];
             $this->hook->getHook('checkout/cart/add/beforeadd', $hook_data);
 
             if (!$json && !$hook_data['json']) {
-                $this->cart->add((int)$this->request->post['product_id'], $quantity, $option, $recurring_id);
+                $this->cart->add((int) $this->request->post['product_id'], $quantity, $option, $recurring_id);
 
-                $json['success'] = sprintf($this->language->get('text_success'),
-                    $this->url->link('product/product',
-                        'product_id=' . $this->request->post['product_id']),
-                    $product_info['name'], $this->url->link('checkout/cart'));
+                $json['success'] = sprintf(
+                    $this->language->get('text_success'),
+                    $this->url->link(
+                        'product/product',
+                        'product_id=' . $this->request->post['product_id']
+                    ),
+                    $product_info['name'],
+                    $this->url->link('checkout/cart')
+                );
                 $json['text_added_to_cart'] = $this->language->get('text_added_to_cart');
 
                 // Deprecated?
-                $json['current_product_in_cart'] = $this->cart->countProducts((int)$this->request->post['product_id']);
+                $json['current_product_in_cart'] = $this->cart->countProducts((int) $this->request->post['product_id']);
                 $json['current_cart_total_count'] = $this->cart->countProducts();
 
-                $json['success'] = sprintf($this->language->get('text_success'), $this->url->link('product/product', 'product_id=' . $this->request->post['product_id']), $product_info['name'],
-                    $this->url->link('checkout/cart'));
+                $json['success'] = sprintf(
+                    $this->language->get('text_success'),
+                    $this->url->link('product/product', 'product_id=' . $this->request->post['product_id']),
+                    $product_info['name'],
+                    $this->url->link('checkout/cart')
+                );
 
                 // Unset all shipping and payment methods
                 unset($this->session->data['shipping_method']);
@@ -356,7 +392,8 @@ class ControllerCheckoutCart extends Controller {
         $this->response->setOutput(json_encode($json));
     }
 
-    public function edit() {
+    public function edit()
+    {
         $this->load->language('checkout/cart');
         $json = [];
         $this->hook->getHook('checkout/cart/edit/before', $this->request->post['quantity']);
@@ -368,7 +405,7 @@ class ControllerCheckoutCart extends Controller {
             // This is Tricky - "too soon" redirect, reason for bugs!
             if (!empty($this->request->post['method']) && $this->request->post['method'] == 'ajax') {
                 $json['status'] = 'OK';
-                $json['current_product_in_cart'] = $this->cart->countProducts((int)$this->request->post['product_id']);
+                $json['current_product_in_cart'] = $this->cart->countProducts((int) $this->request->post['product_id']);
                 $json['current_cart_total_count'] = $this->cart->countProducts();
                 echo json_encode($json);
                 return false;
@@ -389,8 +426,8 @@ class ControllerCheckoutCart extends Controller {
         $this->response->setOutput(json_encode($json));
     }
 
-
-    public function edit_only() {
+    public function edit_only()
+    {
 
         // Update
         if (!empty($this->request->post['quantity'])) {
@@ -411,7 +448,8 @@ class ControllerCheckoutCart extends Controller {
         }
     }
 
-    public function remove() {
+    public function remove()
+    {
         $this->load->language('checkout/cart');
 
         $json = [];
@@ -440,8 +478,8 @@ class ControllerCheckoutCart extends Controller {
             // Because __call can not keep var references so we put them into an array.
             $total_data = [
                 'totals' => &$totals,
-                'taxes'  => &$taxes,
-                'total'  => &$total,
+                'taxes' => &$taxes,
+                'total' => &$total,
             ];
 
             // Display prices
@@ -474,8 +512,11 @@ class ControllerCheckoutCart extends Controller {
                 array_multisort($sort_order, SORT_ASC, $totals);
             }
 
-            $json['total'] = sprintf($this->language->get('text_items'), $this->cart->countProducts() + (isset($this->session->data['vouchers']) ? count($this->session->data['vouchers']) : 0),
-                $this->currency->format($total, $this->session->data['currency']));
+            $json['total'] = sprintf(
+                $this->language->get('text_items'),
+                $this->cart->countProducts() + (isset($this->session->data['vouchers']) ? count($this->session->data['vouchers']) : 0),
+                $this->currency->format($total, $this->session->data['currency'])
+            );
         }
         $json['current_cart_total_count'] = $this->cart->countProducts();
         $this->response->addHeader('Content-Type: application/json');
@@ -487,12 +528,14 @@ class ControllerCheckoutCart extends Controller {
      * @return HTML5_Data
      *
      */
-    public function getCartTable() {
+    public function getCartTable()
+    {
         $data = $this->getCartTableData();
         return $this->load->view('checkout/cart_info', $data);
     }
 
-    public function cart_table() {
+    public function cart_table()
+    {
 
         $this->edit_only();
 
@@ -500,7 +543,8 @@ class ControllerCheckoutCart extends Controller {
         $this->response->setOutput($this->load->view('checkout/cart_info', $data));
     }
 
-    public function getCartTableData() {
+    public function getCartTableData()
+    {
         $data = $this->load->language('checkout/cart');
         $data['heading_title'] = $this->language->get('heading_title');
 
@@ -557,11 +601,17 @@ class ControllerCheckoutCart extends Controller {
             }
 
             if ($product['image']) {
-                $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}($product['image'], $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
-                    $this->config->get($this->config->get('config_theme') . '_image_cart_height'));
+                $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}(
+                    $product['image'],
+                    $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
+                    $this->config->get($this->config->get('config_theme') . '_image_cart_height')
+                );
             } else {
-                $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}(Config::get('config_no_image', 'placeholder.png'),
-                    $this->config->get($this->config->get('config_theme') . '_image_cart_width'), $this->config->get($this->config->get('config_theme') . '_image_cart_height'));
+                $image = $this->model_tool_image->{Config::get('theme_default_product_cart_thumb_resize', 'resize')}(
+                    Config::get('config_no_image', 'placeholder.png'),
+                    $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
+                    $this->config->get($this->config->get('config_theme') . '_image_cart_height')
+                );
             }
 
             $option_data = [];
@@ -580,7 +630,7 @@ class ControllerCheckoutCart extends Controller {
                 }
 
                 $option_data[] = [
-                    'name'  => $option['name'],
+                    'name' => $option['name'],
                     'value' => (utf8_strlen($value) > 20 ? utf8_substr($value, 0, 20) . '..' : $value),
                 ];
             }
@@ -600,45 +650,60 @@ class ControllerCheckoutCart extends Controller {
 
             if ($product['recurring']) {
                 $frequencies = [
-                    'day'        => $this->language->get('text_day'),
-                    'week'       => $this->language->get('text_week'),
+                    'day' => $this->language->get('text_day'),
+                    'week' => $this->language->get('text_week'),
                     'semi_month' => $this->language->get('text_semi_month'),
-                    'month'      => $this->language->get('text_month'),
-                    'year'       => $this->language->get('text_year'),
+                    'month' => $this->language->get('text_month'),
+                    'year' => $this->language->get('text_year'),
                 ];
 
                 if ($product['recurring']['trial']) {
-                    $recurring = sprintf($this->language->get('text_trial_description'),
-                            $this->currency->format($this->tax->calculate($product['recurring']['trial_price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
-                                $this->session->data['currency']), $product['recurring']['trial_cycle'], $frequencies[$product['recurring']['trial_frequency']], $product['recurring']['trial_duration']) . ' ';
+                    $recurring = sprintf(
+                        $this->language->get('text_trial_description'),
+                        $this->currency->format(
+                            $this->tax->calculate($product['recurring']['trial_price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')),
+                            $this->session->data['currency']
+                        ),
+                        $product['recurring']['trial_cycle'],
+                        $frequencies[$product['recurring']['trial_frequency']],
+                        $product['recurring']['trial_duration']
+                    ) . ' ';
                 }
 
                 if ($product['recurring']['duration']) {
-                    $recurring .= sprintf($this->language->get('text_payment_description'),
+                    $recurring .= sprintf(
+                        $this->language->get('text_payment_description'),
                         $this->currency->format($this->tax->calculate($product['recurring']['price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']),
-                        $product['recurring']['cycle'], $frequencies[$product['recurring']['frequency']], $product['recurring']['duration']);
+                        $product['recurring']['cycle'],
+                        $frequencies[$product['recurring']['frequency']],
+                        $product['recurring']['duration']
+                    );
                 } else {
-                    $recurring .= sprintf($this->language->get('text_payment_cancel'),
+                    $recurring .= sprintf(
+                        $this->language->get('text_payment_cancel'),
                         $this->currency->format($this->tax->calculate($product['recurring']['price'] * $product['quantity'], $product['tax_class_id'], $this->config->get('config_tax')), $this->session->data['currency']),
-                        $product['recurring']['cycle'], $frequencies[$product['recurring']['frequency']], $product['recurring']['duration']);
+                        $product['recurring']['cycle'],
+                        $frequencies[$product['recurring']['frequency']],
+                        $product['recurring']['duration']
+                    );
                 }
             }
 
             $data['products'][] = [
-                'cart_id'      => $product['cart_id'],
-                'product_id'   => $product['product_id'],
-                'thumb'        => $image,
-                'name'         => $product['name'],
-                'model'        => $product['model'],
-                'option'       => $option_data,
-                'recurring'    => $recurring,
+                'cart_id' => $product['cart_id'],
+                'product_id' => $product['product_id'],
+                'thumb' => $image,
+                'name' => $product['name'],
+                'model' => $product['model'],
+                'option' => $option_data,
+                'recurring' => $recurring,
                 'content_meta' => $product['content_meta'],
-                'quantity'     => $product['quantity'],
-                'stock'        => $product['stock'] ? true : !(!$this->config->get('config_stock_checkout') || $this->config->get('config_stock_warning')),
-                'reward'       => ($product['reward'] ? sprintf($this->language->get('text_points'), $product['reward']) : ''),
-                'price'        => $price,
-                'total'        => $total,
-                'href'         => $this->url->link('product/product', 'product_id=' . $product['product_id']),
+                'quantity' => $product['quantity'],
+                'stock' => $product['stock'] ? true : !(!$this->config->get('config_stock_checkout') || $this->config->get('config_stock_warning')),
+                'reward' => ($product['reward'] ? sprintf($this->language->get('text_points'), $product['reward']) : ''),
+                'price' => $price,
+                'total' => $total,
+                'href' => $this->url->link('product/product', 'product_id=' . $product['product_id']),
             ];
         }
 
@@ -651,10 +716,10 @@ class ControllerCheckoutCart extends Controller {
         if (!empty($this->session->data['vouchers'])) {
             foreach ($this->session->data['vouchers'] as $key => $voucher) {
                 $data['vouchers'][] = [
-                    'key'         => $key,
+                    'key' => $key,
                     'description' => $voucher['description'],
-                    'amount'      => $this->currency->format($voucher['amount'], $this->session->data['currency']),
-                    'remove'      => $this->url->link('checkout/cart', 'remove=' . $key),
+                    'amount' => $this->currency->format($voucher['amount'], $this->session->data['currency']),
+                    'remove' => $this->url->link('checkout/cart', 'remove=' . $key),
                 ];
             }
         }
@@ -662,7 +727,6 @@ class ControllerCheckoutCart extends Controller {
         // Totals
 
         $data['totals'] = $this->cart->getTotals_azon();
-
 
         $data['continue'] = $this->url->link('common/home');
 
@@ -682,7 +746,6 @@ class ControllerCheckoutCart extends Controller {
                 }
             }
         }
-
 
         return $data;
     }

--- a/catalog/controller/extension/captcha/basic.php
+++ b/catalog/controller/extension/captcha/basic.php
@@ -1,59 +1,64 @@
 <?php
-class ControllerExtensionCaptchaBasic extends Controller {
-	public function index($error = array()) {
-		$this->load->language('extension/captcha/basic');
 
-		if (isset($error['captcha'])) {
-			$data['error_captcha'] = $error['captcha'];
-		} else {
-			$data['error_captcha'] = '';
-		}
+class ControllerExtensionCaptchaBasic extends Controller
+{
+    public function index($error = [])
+    {
+        $this->load->language('extension/captcha/basic');
 
-		$data['route'] = $this->request->get['route']; 
+        if (isset($error['captcha'])) {
+            $data['error_captcha'] = $error['captcha'];
+        } else {
+            $data['error_captcha'] = '';
+        }
 
-		return $this->load->view('extension/captcha/basic', $data);
-	}
+        $data['route'] = $this->request->get['route'];
 
-	public function validate() {
-		$this->load->language('extension/captcha/basic');
+        return $this->load->view('extension/captcha/basic', $data);
+    }
 
-		if (empty($this->session->data['captcha']) || ($this->session->data['captcha'] != $this->request->post['captcha'])) {
-			return $this->language->get('error_captcha');
-		}
-	}
+    public function validate()
+    {
+        $this->load->language('extension/captcha/basic');
 
-	public function captcha() {
-		$this->session->data['captcha'] = substr(token(100), rand(0, 94), 6);
+        if (empty($this->session->data['captcha']) || ($this->session->data['captcha'] != $this->request->post['captcha'])) {
+            return $this->language->get('error_captcha');
+        }
+    }
 
-		$image = imagecreatetruecolor(150, 35);
+    public function captcha()
+    {
+        $this->session->data['captcha'] = substr(token(100), rand(0, 94), 6);
 
-		$width = imagesx($image);
-		$height = imagesy($image);
+        $image = imagecreatetruecolor(150, 35);
 
-		$black = imagecolorallocate($image, 0, 0, 0);
-		$white = imagecolorallocate($image, 255, 255, 255);
-		$red = imagecolorallocatealpha($image, 255, 0, 0, 75);
-		$green = imagecolorallocatealpha($image, 0, 255, 0, 75);
-		$blue = imagecolorallocatealpha($image, 0, 0, 255, 75);
+        $width = imagesx($image);
+        $height = imagesy($image);
 
-		imagefilledrectangle($image, 0, 0, $width, $height, $white);
-		imagefilledellipse($image, ceil(rand(5, 145)), ceil(rand(0, 35)), 30, 30, $red);
-		imagefilledellipse($image, ceil(rand(5, 145)), ceil(rand(0, 35)), 30, 30, $green);
-		imagefilledellipse($image, ceil(rand(5, 145)), ceil(rand(0, 35)), 30, 30, $blue);
-		imagefilledrectangle($image, 0, 0, $width, 0, $black);
-		imagefilledrectangle($image, $width - 1, 0, $width - 1, $height - 1, $black);
-		imagefilledrectangle($image, 0, 0, 0, $height - 1, $black);
-		imagefilledrectangle($image, 0, $height - 1, $width, $height - 1, $black);
+        $black = imagecolorallocate($image, 0, 0, 0);
+        $white = imagecolorallocate($image, 255, 255, 255);
+        $red = imagecolorallocatealpha($image, 255, 0, 0, 75);
+        $green = imagecolorallocatealpha($image, 0, 255, 0, 75);
+        $blue = imagecolorallocatealpha($image, 0, 0, 255, 75);
 
-		imagestring($image, 10, intval(($width - (strlen($this->session->data['captcha']) * 9)) / 2), intval(($height - 15) / 2), $this->session->data['captcha'], $black);
+        imagefilledrectangle($image, 0, 0, $width, $height, $white);
+        imagefilledellipse($image, ceil(rand(5, 145)), ceil(rand(0, 35)), 30, 30, $red);
+        imagefilledellipse($image, ceil(rand(5, 145)), ceil(rand(0, 35)), 30, 30, $green);
+        imagefilledellipse($image, ceil(rand(5, 145)), ceil(rand(0, 35)), 30, 30, $blue);
+        imagefilledrectangle($image, 0, 0, $width, 0, $black);
+        imagefilledrectangle($image, $width - 1, 0, $width - 1, $height - 1, $black);
+        imagefilledrectangle($image, 0, 0, 0, $height - 1, $black);
+        imagefilledrectangle($image, 0, $height - 1, $width, $height - 1, $black);
 
-		header('Content-type: image/jpeg');
-		header('Cache-Control: no-cache');
-		header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
+        imagestring($image, 10, intval(($width - (strlen($this->session->data['captcha']) * 9)) / 2), intval(($height - 15) / 2), $this->session->data['captcha'], $black);
 
-		imagejpeg($image);
+        header('Content-type: image/jpeg');
+        header('Cache-Control: no-cache');
+        header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
 
-		imagedestroy($image);
-		exit();
-	}
+        imagejpeg($image);
+
+        imagedestroy($image);
+        exit();
+    }
 }

--- a/catalog/controller/extension/captcha/google.php
+++ b/catalog/controller/extension/captcha/google.php
@@ -1,38 +1,42 @@
 <?php
-class ControllerExtensionCaptchaGoogle extends Controller {
-    public function index($error = array()) {
+
+class ControllerExtensionCaptchaGoogle extends Controller
+{
+    public function index($error = [])
+    {
         $data = $this->load->language('extension/captcha/google');
 
         if (isset($error['captcha'])) {
-			$data['error_captcha'] = $error['captcha'];
-		} else {
-			$data['error_captcha'] = '';
-		}
+            $data['error_captcha'] = $error['captcha'];
+        } else {
+            $data['error_captcha'] = '';
+        }
 
-		$data['site_key'] = $this->config->get('captcha_google_key');
+        $data['site_key'] = $this->config->get('captcha_google_key');
 
-        $data['route'] = $this->request->get['route']; 
+        $data['route'] = $this->request->get['route'];
 
-		return $this->load->view('extension/captcha/google', $data);
+        return $this->load->view('extension/captcha/google', $data);
     }
 
-    public function validate() {
-		if (empty($this->session->data['gcapcha'])) {
-			$this->load->language('extension/captcha/google');
+    public function validate()
+    {
+        if (empty($this->session->data['gcapcha'])) {
+            $this->load->language('extension/captcha/google');
 
-			if (!isset($this->request->post['g-recaptcha-response'])) {
-				return $this->language->get('error_captcha');
-			}
+            if (!isset($this->request->post['g-recaptcha-response'])) {
+                return $this->language->get('error_captcha');
+            }
 
-			$recaptcha = file_get_contents('https://www.google.com/recaptcha/api/siteverify?secret=' . urlencode($this->config->get('captcha_google_secret')) . '&response=' . $this->request->post['g-recaptcha-response'] . '&remoteip=' . $this->request->server['REMOTE_ADDR']);
+            $recaptcha = file_get_contents('https://www.google.com/recaptcha/api/siteverify?secret=' . urlencode($this->config->get('captcha_google_secret')) . '&response=' . $this->request->post['g-recaptcha-response'] . '&remoteip=' . $this->request->server['REMOTE_ADDR']);
 
-			$recaptcha = json_decode($recaptcha, true);
+            $recaptcha = json_decode($recaptcha, true);
 
-			if ($recaptcha['success']) {
-				$this->session->data['gcapcha']	= true;
-			} else {
-				return $this->language->get('error_captcha');
-			}
-		}
+            if ($recaptcha['success']) {
+                $this->session->data['gcapcha'] = true;
+            } else {
+                return $this->language->get('error_captcha');
+            }
+        }
     }
 }

--- a/catalog/controller/extension/module/categoryfeatured.php
+++ b/catalog/controller/extension/module/categoryfeatured.php
@@ -1,7 +1,9 @@
 <?php
-class ControllerExtensionModuleCategoryFeatured extends Controller {
 
-    public function index($setting) {
+class ControllerExtensionModuleCategoryFeatured extends Controller
+{
+    public function index($setting)
+    {
 
         $this->load->language('extension/module/categoryfeatured');
 
@@ -9,14 +11,14 @@ class ControllerExtensionModuleCategoryFeatured extends Controller {
 
         $this->load->model('catalog/category');
         $this->load->model('tool/image');
-        $data['categories'] = array();
+        $data['categories'] = [];
 
         if (!$setting['limit']) {
             $setting['limit'] = 4;
         }
 
         if (!empty($setting['category'])) {
-            $categories = array_slice($setting['category'], 0, (int)$setting['limit']);
+            $categories = array_slice($setting['category'], 0, (int) $setting['limit']);
 
             foreach ($categories as $category_id) {
                 $category_info = $this->model_catalog_category->getCategory($category_id);
@@ -25,16 +27,16 @@ class ControllerExtensionModuleCategoryFeatured extends Controller {
                     if ($category_info['image']) {
                         $image = $this->model_tool_image->resize($category_info['image'], $setting['width'], $setting['height']);
                     } else {
-                        $image = $this->model_tool_image->resize(Config::get('config_no_image','placeholder.png'), $setting['width'], $setting['height']);
+                        $image = $this->model_tool_image->resize(Config::get('config_no_image', 'placeholder.png'), $setting['width'], $setting['height']);
                     }
 
-                    $data['categories'][] = array(
+                    $data['categories'][] = [
                         'category_id' => $category_info['category_id'],
-                        'thumb'       => $image,
-                        'name'        => $category_info['name'],
+                        'thumb' => $image,
+                        'name' => $category_info['name'],
                         'description' => utf8_substr(strip_tags(html_entity_decode($category_info['description'], ENT_QUOTES, 'UTF-8')), 0, $this->config->get($this->config->get('config_theme') . '_category_description_length')) . '..',
-                        'href'        => $this->url->link('product/category', 'path=' . $category_info['category_id'])
-                    );
+                        'href' => $this->url->link('product/category', 'path=' . $category_info['category_id']),
+                    ];
                 }
             }
         }

--- a/catalog/controller/extension/payment/bank_transfer.php
+++ b/catalog/controller/extension/payment/bank_transfer.php
@@ -1,7 +1,9 @@
 <?php
 
-class ControllerExtensionPaymentBankTransfer extends Controller {
-    public function index() {
+class ControllerExtensionPaymentBankTransfer extends Controller
+{
+    public function index()
+    {
         $this->load->language('extension/payment/bank_transfer');
 
         $data['text_instruction'] = $this->language->get('text_instruction');
@@ -19,7 +21,8 @@ class ControllerExtensionPaymentBankTransfer extends Controller {
         return $this->load->view('extension/payment/bank_transfer', $data);
     }
 
-    public function confirm() {
+    public function confirm()
+    {
 
         $json = [];
 
@@ -32,12 +35,16 @@ class ControllerExtensionPaymentBankTransfer extends Controller {
             $instruction = html_entity_decode($instruction, ENT_QUOTES, 'UTF-8');
             $instruction = html_to_plaintext($instruction, true);
 
-            $comment = $this->language->get('text_instruction') . ":";
+            $comment = $this->language->get('text_instruction') . ':';
             $comment .= $instruction;
             $comment .= $this->language->get('text_payment');
 
-            $this->model_checkout_order->addOrderHistory($this->session->data['order_id'],
-                $this->config->get('bank_transfer_order_status_id'), $comment, true);
+            $this->model_checkout_order->addOrderHistory(
+                $this->session->data['order_id'],
+                $this->config->get('bank_transfer_order_status_id'),
+                $comment,
+                true
+            );
 
             $json['message'] = 'Order created!';
             $json['order_id'] = $this->session->data['order_id'];

--- a/catalog/language/en-gb/common/home.php
+++ b/catalog/language/en-gb/common/home.php
@@ -1,4 +1,5 @@
 <?php
+
 // Heading
 $_['heading_title'] = '';
 $_['meta_tag_description'] = '';

--- a/catalog/language/en-gb/extension/captcha/basic.php
+++ b/catalog/language/en-gb/extension/captcha/basic.php
@@ -1,6 +1,7 @@
 <?php
+
 // Text
-$_['text_captcha']  = 'Captcha';
+$_['text_captcha'] = 'Captcha';
 
 // Entry
 $_['entry_captcha'] = 'Enter the code in the box below';

--- a/catalog/language/en-gb/extension/module/simpleform.php
+++ b/catalog/language/en-gb/extension/module/simpleform.php
@@ -1,4 +1,5 @@
 <?php
+
 $_['heading_title'] = 'Nepraleiskite progos ir papuoškite savo „Porsche“ originaliais ratais:';
 $_['text_contact'] = 'Sazinaties ar mums';
 $_['text_sitemap'] = 'Vietnes karte';
@@ -9,4 +10,3 @@ $_['text_registration_email'] = 'Elektroninis paštas';
 $_['text_registration_regnumber'] = 'Jūsų vairuojamas automobilis';
 $_['text_registration_warning'] = 'Būtini laukai. Gavę Jūsų užklausą su Jumis sisisieksime asmeniškai.';
 $_['text_registration_title'] = 'Registracija pasiūlymui gauti';
-?>

--- a/catalog/model/extension/module/simpleform.php
+++ b/catalog/model/extension/module/simpleform.php
@@ -1,15 +1,16 @@
 <?php
-class ModelExtensionModuleSimpleform extends Model {
 
-    public function saveFormData($data) {
-
+class ModelExtensionModuleSimpleform extends Model
+{
+    public function saveFormData($data)
+    {
 
         //TODO: move to admin?
         // installation
         $res = $this->db->query("SHOW TABLES LIKE '" . DB_PREFIX . "simpleform'");
 
-        if (!(boolean)$res->num_rows) {
-            $sql = "CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "simpleform` (
+        if (!(bool) $res->num_rows) {
+            $sql = 'CREATE TABLE IF NOT EXISTS `' . DB_PREFIX . 'simpleform` (
 				id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
 				`name` varchar(254) NOT NULL,
 				`surname` varchar(254) NOT NULL,
@@ -20,12 +21,11 @@ class ModelExtensionModuleSimpleform extends Model {
 				`form_id` varchar(254) NULL,
 				`regnumber` varchar(254) NULL,
 				`link` varchar(254) NULL,
-				`date` TIMESTAMP ) CHARSET=utf8";
+				`date` TIMESTAMP ) CHARSET=utf8';
             $this->db->query($sql);
         }
 
-
-        $sql = "INSERT INTO " . DB_PREFIX . "simpleform
+        $sql = 'INSERT INTO ' . DB_PREFIX . "simpleform
         SET
         name = '" . $this->db->escape(isset($data['name']) ? $data['name'] : '') . "',
         surname = '" . $this->db->escape(isset($data['surname']) ? $data['surname'] : '') . "',
@@ -34,23 +34,22 @@ class ModelExtensionModuleSimpleform extends Model {
         email = '" . $this->db->escape(isset($data['email']) ? $data['email'] : '') . "',
         month = '" . $this->db->escape(isset($data['month']) ? $data['month'] : '') . "',
         form_id = '" . $this->db->escape(isset($data['form_id']) ? $data['form_id'] : '') . "',
-        link = '" . $this->db->escape(isset($data['link']) ? $data['link'] : '' ) . "',
+        link = '" . $this->db->escape(isset($data['link']) ? $data['link'] : '') . "',
         regnumber = '" . $this->db->escape(isset($data['regnumber']) ? $data['regnumber'] : '') . "'";
         //prd($sql);
-
 
         $result = $this->db->query($sql);
 
         if ($result) {
-            $subject = "Simple webform email";
+            $subject = 'Simple webform email';
             $message = "\nNew request from website!\n\n\n";
-            $message .= "Name: " . $data['name'] . "\n";
-            $message .= "Surname: " . $data['surname'] . "\n";
-            $message .= "Phone: " . $data['phone'] . "\n";
-            $message .= "Email: " . $data['email'] . "\n";
-            $message .= "regnumber: " . (isset($data['regnumber']) ? $data['regnumber'] : '') . "\n";
-            $message .= "address: " . (isset($data['address']) ? $data['address'] : '') . "\n";
-            $message .= "month: " . (isset($data['month']) ? $data['month'] : '') . "\n";
+            $message .= 'Name: ' . $data['name'] . "\n";
+            $message .= 'Surname: ' . $data['surname'] . "\n";
+            $message .= 'Phone: ' . $data['phone'] . "\n";
+            $message .= 'Email: ' . $data['email'] . "\n";
+            $message .= 'regnumber: ' . (isset($data['regnumber']) ? $data['regnumber'] : '') . "\n";
+            $message .= 'address: ' . (isset($data['address']) ? $data['address'] : '') . "\n";
+            $message .= 'month: ' . (isset($data['month']) ? $data['month'] : '') . "\n";
             $mail = new Mail();
             $mail->protocol = $this->config->get('config_mail_protocol');
             $mail->parameter = $this->config->get('config_mail_parameter');
@@ -61,7 +60,7 @@ class ModelExtensionModuleSimpleform extends Model {
             $mail->timeout = $this->config->get('config_smtp_timeout');
             $mail->setTo($this->config->get('config_email'));
             $mail->setFrom($this->config->get('config_email'));
-            $mail->setSender("Porsche Web site");
+            $mail->setSender('Porsche Web site');
             $mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
             $mail->setText(html_entity_decode($message, ENT_QUOTES, 'UTF-8'));
             $mail->send();

--- a/catalog/model/tool/mail.php
+++ b/catalog/model/tool/mail.php
@@ -13,16 +13,15 @@ class ModelToolMail extends Model
      * @param int $store_id
      * @param string $store_name taken from store value, if set.
      */
-    public function sendMail($from_email = '',
-                             $to_email = '',
-                             $subject = '',
-                             $data = [],
-                             $template = '',
-                             $store_id = 0,
-                             $store_name = ''
-    )
-    {
-
+    public function sendMail(
+        $from_email = '',
+        $to_email = '',
+        $subject = '',
+        $data = [],
+        $template = '',
+        $store_id = 0,
+        $store_name = ''
+    ) {
 
         $this->load->model('setting/setting');
         // $text = $data['message'];
@@ -31,7 +30,7 @@ class ModelToolMail extends Model
         // store_name: $order_info['store_name']
         $html_message = '';
 
-        if($this->config->get('config_mail_protocol') == 'smtp') {
+        if ($this->config->get('config_mail_protocol') == 'smtp') {
             $from_email = $this->config->get('config_mail_smtp_from_email');
         }
 
@@ -58,16 +57,16 @@ class ModelToolMail extends Model
             $html_message = $this->load->view($template, $data);
         }
 
-
-
-
         $mail = new Mail();
         $mail->protocol = $this->config->get('config_mail_protocol');
         $mail->parameter = $this->config->get('config_mail_parameter');
         $mail->smtp_hostname = $this->config->get('config_mail_smtp_hostname');
         $mail->smtp_username = $this->config->get('config_mail_smtp_username');
-        $mail->smtp_password = html_entity_decode($this->config->get('config_mail_smtp_password'), ENT_QUOTES,
-            'UTF-8');
+        $mail->smtp_password = html_entity_decode(
+            $this->config->get('config_mail_smtp_password'),
+            ENT_QUOTES,
+            'UTF-8'
+        );
         $mail->smtp_port = $this->config->get('config_mail_smtp_port');
         $mail->smtp_timeout = $this->config->get('config_mail_smtp_timeout');
 
@@ -76,7 +75,7 @@ class ModelToolMail extends Model
         $mail->setSender(html_entity_decode($from_name, ENT_QUOTES, 'UTF-8'));
         $mail->setSubject(html_entity_decode($subject, ENT_QUOTES, 'UTF-8'));
 
-        if($html_message) {
+        if ($html_message) {
             $mail->setHtml($html_message);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,12 @@
     }
   },
   "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.95",
+    "phpstan/phpstan": "^2.2"
+  },
+  "scripts": {
+    "cs-fix":   "php-cs-fixer fix --diff",
+    "cs-check": "php-cs-fixer fix --dry-run --diff",
+    "analyse":  "phpstan analyse"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "780827c561a43426823c2ea08ecd3654",
+    "content-hash": "ac823ab5238ddc1e50f53d0f637f1df2",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -6017,7 +6017,1530 @@
             "time": "2026-04-26T05:33:54+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "ergebnis/agent-detector",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "e211f17928c8b95a51e06040792d57f5462fb271"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/e211f17928c8b95a51e06040792d57f5462fb271",
+                "reference": "e211f17928c8b95a51e06040792d57f5462fb271",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.51.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.18.1",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.54",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-05-07T08:19:07+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.95.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
+                "reference": "7f86d8763063f5d2e2e2d0e1e45bb2f15895361d",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.3",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.2",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.3",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.6",
+                "react/event-loop": "^1.5",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0 || ^9.0",
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.37",
+                "symfony/polyfill-php80": "^1.37",
+                "symfony/polyfill-php81": "^1.37",
+                "symfony/polyfill-php84": "^1.37",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.11.0",
+                "infection/infection": "^0.32.7",
+                "justinrainbow/json-schema": "^6.8.0",
+                "keradus/cli-executor": "^2.3",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
+                "symfony/polyfill-php85": "^1.37",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.11"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/**/Internal/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-09T14:55:16+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-05T09:00:01+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.7"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-12-23T15:25:20+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:46+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6367 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Constant DIR_APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/account/account.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 10
+			path: catalog/controller/account/address.php
+
+		-
+			message: '#^Constant DIR_DOWNLOAD not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/controller/account/download.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 5
+			path: catalog/controller/account/edit.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/account/forgotten.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/account/login.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/account/order.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/account/order.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/account/password.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/account/register.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 13
+			path: catalog/controller/account/register.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/account/reset.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 11
+			path: catalog/controller/account/return.php
+
+		-
+			message: '#^Access to an undefined property ControllerAccountVoucher\:\:\$model_extension_total_voucher_theme\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/account/voucher.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 6
+			path: catalog/controller/account/voucher.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 13
+			path: catalog/controller/affiliate/edit.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/affiliate/forgotten.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/affiliate/password.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 15
+			path: catalog/controller/affiliate/register.php
+
+		-
+			message: '#^Access to an undefined property ControllerApiAjax\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/api/ajax.php
+
+		-
+			message: '#^Access to an undefined property ControllerApiCoupon\:\:\$model_extension_total_coupon\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/api/coupon.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 7
+			path: catalog/controller/api/customer.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/api/order.php
+
+		-
+			message: '#^Variable \$shipping might not be defined\.$#'
+			identifier: variable.undefined
+			count: 4
+			path: catalog/controller/api/order.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 10
+			path: catalog/controller/api/payment.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 10
+			path: catalog/controller/api/shipping.php
+
+		-
+			message: '#^Variable \$shipping might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/api/shipping.php
+
+		-
+			message: '#^Access to an undefined property ControllerApiVoucher\:\:\$model_extension_total_voucher\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/api/voucher.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 6
+			path: catalog/controller/api/voucher.php
+
+		-
+			message: '#^Access to an undefined property ControllerCheckoutCart\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/controller/checkout/cart.php
+
+		-
+			message: '#^Constant DIR_APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/controller/checkout/cart.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/checkout/cart.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/checkout/cart.php
+
+		-
+			message: '#^Access to an undefined property ControllerCheckoutCheckout\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/controller/checkout/checkout.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 8
+			path: catalog/controller/checkout/checkout.php
+
+		-
+			message: '#^Variable \$customer_full_info might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/checkout/checkout.php
+
+		-
+			message: '#^Access to an undefined property ControllerCheckoutConfirm\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/checkout/confirm.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/checkout/confirm.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/checkout/confirm.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/checkout/confirm.php
+
+		-
+			message: '#^Variable \$shipping_address might not be defined\.$#'
+			identifier: variable.undefined
+			count: 11
+			path: catalog/controller/checkout/confirm.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 10
+			path: catalog/controller/checkout/guest_shipping.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 10
+			path: catalog/controller/checkout/payment_address.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 15
+			path: catalog/controller/checkout/register.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 10
+			path: catalog/controller/checkout/shipping_address.php
+
+		-
+			message: '#^Variable \$shipping might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/checkout/shipping_method.php
+
+		-
+			message: '#^Access to an undefined property ControllerCommonFooter\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/common/footer.php
+
+		-
+			message: '#^Access to an undefined property ControllerCommonHeader\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/common/header.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/controller/common/header.php
+
+		-
+			message: '#^Access to an undefined property ControllerCommonHome\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/common/home.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: catalog/controller/common/youtube.php
+
+		-
+			message: '#^Function prd not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/common/youtube.php
+
+		-
+			message: '#^Variable \$id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/common/youtube.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/captcha/basic.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionCreditCardSagepayDirect\:\:\$model_extension_payment_sagepay_direct\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/controller/extension/credit_card/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionCreditCardSagepayServer\:\:\$model_extension_payment_sagepay_server\.$#'
+			identifier: property.notFound
+			count: 21
+			path: catalog/controller/extension/credit_card/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionFeedGoogleBase\:\:\$model_extension_feed_google_base\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/feed/google_base.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleAccount\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/account.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleAmazonLogin\:\:\$error\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/controller/extension/module/amazon_login.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleAmazonLogin\:\:\$model_extension_payment_amazon_login_pay\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/controller/extension/module/amazon_login.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleAmazonPay\:\:\$error\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/controller/extension/module/amazon_pay.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleAmazonPay\:\:\$model_extension_payment_amazon_login_pay\.$#'
+			identifier: property.notFound
+			count: 11
+			path: catalog/controller/extension/module/amazon_pay.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/module/banner.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/module/bestseller.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/module/carousel.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/module/categoryfeatured.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleDividoCalculator\:\:\$model_extension_payment_divido\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/controller/extension/module/divido_calculator.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleFeatured\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/featured.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/module/featured.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleKlarnaCheckoutModule\:\:\$model_extension_payment_klarna_checkout\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/controller/extension/module/klarna_checkout_module.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleLatest\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/latest.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/module/latest.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleLaybuyLayout\:\:\$model_extension_module_laybuy_layout\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/controller/extension/module/laybuy_layout.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleManufacturers\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/manufacturers.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/controller/extension/module/manufacturers.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModulePPLogin\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/controller/extension/module/pp_login.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModulePPLogin\:\:\$model_extension_module_pp_login\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/controller/extension/module/pp_login.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/controller/extension/module/pp_login.php
+
+		-
+			message: '#^Variable \$tokens might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/module/pp_login.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleSimpleform\:\:\$model_catalog_infocategory\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/simpleform.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleSimpleform\:\:\$model_extension_module_simpleform\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/simpleform.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleSimpleform\:\:\$model_information_infocategory\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/simpleform.php
+
+		-
+			message: '#^Call to an undefined method ControllerExtensionModuleSimpleform\:\:redirect\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: catalog/controller/extension/module/simpleform.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/extension/module/simpleform.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleSlideshow\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/slideshow.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/module/slideshow.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionModuleSpecial\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/module/special.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/module/special.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/module/store.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentAmazonLoginPay\:\:\$model_extension_payment_amazon_login_pay\.$#'
+			identifier: property.notFound
+			count: 31
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentAmazonLoginPay\:\:\$model_extension_total_coupon\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Function utf8_strrpos not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Offset int\<\-1, max\> on array\{\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$address_1 might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$address_2 might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$address_format might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$country_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$country_name might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$iso_code2 might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$iso_code3 might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/authorizenet_aim.php
+
+		-
+			message: '#^Undefined variable\: \$details$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/authorizenet_sim.php
+
+		-
+			message: '#^Function html_to_plaintext not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentBluePayHosted\:\:\$model_extension_payment_bluepay_hosted\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/controller/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentBluePayRedirect\:\:\$model_extension_payment_bluepay_redirect\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/controller/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentCardConnect\:\:\$model_extension_payment_cardconnect\.$#'
+			identifier: property.notFound
+			count: 39
+			path: catalog/controller/extension/payment/cardconnect.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 8
+			path: catalog/controller/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentCardinity\:\:\$model_extension_payment_cardinity\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/controller/extension/payment/cardinity.php
+
+		-
+			message: '#^Caught class Cardinity\\Exception\\Declined not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/controller/extension/payment/cardinity.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 6
+			path: catalog/controller/extension/payment/cardinity.php
+
+		-
+			message: '#^Variable \$order_info might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/cardinity.php
+
+		-
+			message: '#^Variable \$payment might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/cardinity.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentDivido\:\:\$model_extension_payment_divido\.$#'
+			identifier: property.notFound
+			count: 13
+			path: catalog/controller/extension/payment/divido.php
+
+		-
+			message: '#^Variable \$email might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/divido.php
+
+		-
+			message: '#^Variable \$firstname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/divido.php
+
+		-
+			message: '#^Variable \$lastname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/divido.php
+
+		-
+			message: '#^Variable \$telephone might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentEway\:\:\$model_extension_payment_eway\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/controller/extension/payment/eway.php
+
+		-
+			message: '#^Constant VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/eway.php
+
+		-
+			message: '#^Variable \$fraud might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/eway.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentFirstdata\:\:\$model_extension_payment_firstdata\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/controller/extension/payment/firstdata.php
+
+		-
+			message: '#^Constant VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentFirstdataRemote\:\:\$model_extension_payment_firstdata_remote\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/controller/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentG2APay\:\:\$model_extension_payment_g2apay\.$#'
+			identifier: property.notFound
+			count: 11
+			path: catalog/controller/extension/payment/g2apay.php
+
+		-
+			message: '#^Offset ''totals'' on array\{\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
+			count: 1
+			path: catalog/controller/extension/payment/g2apay.php
+
+		-
+			message: '#^Variable \$items might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/g2apay.php
+
+		-
+			message: '#^Variable \$order_status_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/g2apay.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentKlarnaAccount\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Constant VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Variable \$country might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Variable \$currency might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Variable \$encoding might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Variable \$goods_list might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Variable \$language might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentKlarnaCheckout\:\:\$model_extension_payment_klarna_checkout\.$#'
+			identifier: property.notFound
+			count: 72
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Cannot unset offset ''shipping_method'' on array\{text_choose_shipping_method\: mixed, text_shipping_method\: mixed, text_no_shipping\: mixed, button_remove\: mixed, shipping_required\: mixed\}\.$#'
+			identifier: unset.offset
+			count: 1
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 38
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Variable \$klarna_checkout_order might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Variable \$klarna_checkout_order_data might not be defined\.$#'
+			identifier: variable.undefined
+			count: 8
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Variable \$order_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 7
+			path: catalog/controller/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentKlarnaInvoice\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Constant VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Variable \$country might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Variable \$currency might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Variable \$encoding might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Variable \$goods_list might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Variable \$language might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentLaybuy\:\:\$model_extension_payment_laybuy\.$#'
+			identifier: property.notFound
+			count: 70
+			path: catalog/controller/extension/payment/laybuy.php
+
+		-
+			message: '#^Variable \$month might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: catalog/controller/extension/payment/laybuy.php
+
+		-
+			message: '#^Variable \$next_payment_date might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentMastercardPGS\:\:\$model_extension_payment_mastercard_pgs\.$#'
+			identifier: property.notFound
+			count: 24
+			path: catalog/controller/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 6
+			path: catalog/controller/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 36
+			path: catalog/controller/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Variable \$order_status_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Variable \$result_tax_data in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: catalog/controller/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Constant HTTPS_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/paypoint.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/paypoint.php
+
+		-
+			message: '#^Variable \$json might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/perpetual_payments.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPilibaba\:\:\$model_extension_payment_pilibaba\.$#'
+			identifier: property.notFound
+			count: 25
+			path: catalog/controller/extension/payment/pilibaba.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pilibaba.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPPExpress\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 37
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPPExpress\:\:\$model_extension_payment_pp_express\.$#'
+			identifier: property.notFound
+			count: 36
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPPExpress\:\:\$model_extension_total_coupon\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPPExpress\:\:\$model_extension_total_voucher\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 25
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Variable \$order_status_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Variable \$payment_address might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Variable \$shipping_address might not be defined\.$#'
+			identifier: variable.undefined
+			count: 12
+			path: catalog/controller/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPPPayflowIframe\:\:\$model_extension_payment_pp_payflow_iframe\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/controller/extension/payment/pp_payflow_iframe.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentPPProIframe\:\:\$model_extension_payment_pp_pro_iframe\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/controller/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Constant DIR_APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_standard.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/extension/payment/pp_standard.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentSagepayDirect\:\:\$model_extension_payment_sagepay_direct\.$#'
+			identifier: property.notFound
+			count: 33
+			path: catalog/controller/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Variable \$url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentSagepayServer\:\:\$model_extension_payment_sagepay_server\.$#'
+			identifier: property.notFound
+			count: 26
+			path: catalog/controller/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Variable \$url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentSecureTradingPp\:\:\$model_extension_payment_securetrading_pp\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/controller/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentSecureTradingWs\:\:\$model_extension_payment_securetrading_ws\.$#'
+			identifier: property.notFound
+			count: 15
+			path: catalog/controller/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Variable \$md5hash might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/skrill.php
+
+		-
+			message: '#^Variable \$md5sig might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/controller/extension/payment/skrill.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionPaymentWorldpay\:\:\$model_extension_payment_worldpay\.$#'
+			identifier: property.notFound
+			count: 18
+			path: catalog/controller/extension/payment/worldpay.php
+
+		-
+			message: '#^Variable \$order_status_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/extension/payment/worldpay.php
+
+		-
+			message: '#^Array has 2 duplicate keys with value ''METHOD'' \(''METHOD'', ''METHOD''\)\.$#'
+			identifier: array.duplicateKey
+			count: 1
+			path: catalog/controller/extension/recurring/pp_express.php
+
+		-
+			message: '#^Call to an undefined method ControllerExtensionRecurringPPExpress\:\:log\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: catalog/controller/extension/recurring/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionTotalCoupon\:\:\$model_extension_total_coupon\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/total/coupon.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/extension/total/shipping.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionTotalVoucher\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/total/voucher.php
+
+		-
+			message: '#^Access to an undefined property ControllerExtensionTotalVoucher\:\:\$model_extension_total_voucher\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/extension/total/voucher.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/controller/extension/total/voucher.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/extension/total/voucher.php
+
+		-
+			message: '#^Function strip2words not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/information/contact.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 4
+			path: catalog/controller/information/contact.php
+
+		-
+			message: '#^Access to an undefined property ControllerInformationInformation\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/information/information.php
+
+		-
+			message: '#^Function strip2words not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/information/information.php
+
+		-
+			message: '#^Access to an undefined property ControllerProductCategory\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/controller/product/category.php
+
+		-
+			message: '#^Function strip2words not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/product/category.php
+
+		-
+			message: '#^Access to an undefined property ControllerProductCompare\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/product/compare.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/product/compare.php
+
+		-
+			message: '#^Function utf8_strtoupper not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/product/manufacturer.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 3
+			path: catalog/controller/product/manufacturer.php
+
+		-
+			message: '#^Access to an undefined property ControllerProductProduct\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/controller/product/product.php
+
+		-
+			message: '#^Function strip2words not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/product/product.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 4
+			path: catalog/controller/product/product.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/product/product.php
+
+		-
+			message: '#^Access to an undefined property ControllerProductSearch\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/controller/product/search.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/product/search.php
+
+		-
+			message: '#^Access to an undefined property ControllerProductSpecial\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/controller/product/special.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/product/special.php
+
+		-
+			message: '#^Undefined variable\: \$data$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/startup/router.php
+
+		-
+			message: '#^Access to an undefined property ControllerStartupSeoUrl\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/controller/startup/seo_url.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/controller/startup/seo_url.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/startup/seo_url.php
+
+		-
+			message: '#^Access to an undefined property ControllerStartupSession\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/controller/startup/session.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: catalog/controller/startup/session.php
+
+		-
+			message: '#^Access to an undefined property ControllerStartupStartup\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/controller/startup/startup.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: catalog/controller/startup/startup.php
+
+		-
+			message: '#^Constant DIR_TEMPLATE not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/controller/startup/startup.php
+
+		-
+			message: '#^Constant HTTPS_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/startup/startup.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/controller/startup/startup.php
+
+		-
+			message: '#^Constant DIR_UPLOAD not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/controller/tool/upload.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/controller/tool/upload.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/controller/tool/upload.php
+
+		-
+			message: '#^Variable \$filename might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/controller/tool/upload.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountActivity\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/account/activity.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountActivity\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/account/activity.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/account/activity.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountAddress\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/account/address.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountAddress\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 29
+			path: catalog/model/account/address.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 12
+			path: catalog/model/account/address.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountApi\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/account/api.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/account/api.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/account/api.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomField\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/account/custom_field.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomField\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/account/custom_field.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 9
+			path: catalog/model/account/custom_field.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 30
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 59
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 14
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$model_account_customer_group\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomer\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 20
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Function utf8_strtolower not found\.$#'
+			identifier: function.notFound
+			count: 8
+			path: catalog/model/account/customer.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomerGroup\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/account/customer_group.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountCustomerGroup\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/account/customer_group.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: catalog/model/account/customer_group.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountDownload\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/account/download.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountDownload\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/download.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountDownload\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/download.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 12
+			path: catalog/model/account/download.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountOrder\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/account/order.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountOrder\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/order.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountOrder\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 15
+			path: catalog/model/account/order.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 17
+			path: catalog/model/account/order.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountRecurring\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/recurring.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountRecurring\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/account/recurring.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 10
+			path: catalog/model/account/recurring.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountReturn\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/account/return.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountReturn\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/account/return.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountReturn\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 14
+			path: catalog/model/account/return.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 10
+			path: catalog/model/account/return.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountReward\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountReward\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/reward.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/account/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountSearch\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/account/search.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountSearch\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/search.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/account/search.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountTransaction\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/transaction.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountTransaction\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/account/transaction.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/account/transaction.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountWishlist\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/account/wishlist.php
+
+		-
+			message: '#^Access to an undefined property ModelAccountWishlist\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/account/wishlist.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: catalog/model/account/wishlist.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateActivity\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/affiliate/activity.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateActivity\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/affiliate/activity.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/affiliate/activity.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$affiliate\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 31
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 73
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 19
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateAffiliate\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 16
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Function utf8_strtolower not found\.$#'
+			identifier: function.notFound
+			count: 7
+			path: catalog/model/affiliate/affiliate.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateTransaction\:\:\$affiliate\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/affiliate/transaction.php
+
+		-
+			message: '#^Access to an undefined property ModelAffiliateTransaction\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/affiliate/transaction.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/affiliate/transaction.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogCategory\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/catalog/category.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogCategory\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/catalog/category.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogCategory\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/model/catalog/category.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 24
+			path: catalog/model/catalog/category.php
+
+		-
+			message: '#^Constant HTTP_SERVER not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: catalog/model/catalog/category.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogContent\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/catalog/content.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/catalog/content.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogInformation\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/catalog/information.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogInformation\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/catalog/information.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 8
+			path: catalog/model/catalog/information.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogManufacturer\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/catalog/manufacturer.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogManufacturer\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/catalog/manufacturer.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogManufacturer\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/catalog/manufacturer.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 12
+			path: catalog/model/catalog/manufacturer.php
+
+		-
+			message: '#^Function prd not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/catalog/manufacturer.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 51
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 41
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$hook\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$model_catalog_category\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$model_catalog_content\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogProduct\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 84
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Function utf8_strtolower not found\.$#'
+			identifier: function.notFound
+			count: 14
+			path: catalog/model/catalog/product.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogReview\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 15
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogReview\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogReview\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogReview\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogReview\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Access to an undefined property ModelCatalogReview\:\:\$model_catalog_product\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 7
+			path: catalog/model/catalog/review.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutMarketing\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/checkout/marketing.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/checkout/marketing.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 22
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 163
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_account_customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_affiliate_affiliate\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_catalog_content\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_extension_extension\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_extension_total_voucher\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_localisation_language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_tool_mail\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutOrder\:\:\$model_tool_upload\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 52
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 3
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Function utf8_strrpos not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 4
+			path: catalog/model/checkout/order.php
+
+		-
+			message: '#^Access to an undefined property ModelCheckoutRecurring\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 11
+			path: catalog/model/checkout/recurring.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/checkout/recurring.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignBanner\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/design/banner.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignBanner\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/design/banner.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/design/banner.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignLayout\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/design/layout.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignLayout\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/design/layout.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignLayout\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/design/layout.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignLayout\:\:\$language_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/design/layout.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/design/layout.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignTheme\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/design/theme.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignTheme\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/design/theme.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/design/theme.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignTranslation\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/design/translation.php
+
+		-
+			message: '#^Access to an undefined property ModelDesignTranslation\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/design/translation.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/design/translation.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionEvent\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/event.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/event.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionExtension\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/extension.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/extension.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFeedGoogleBase\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/feed/google_base.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFeedGoogleBase\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/feed/google_base.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: catalog/model/extension/feed/google_base.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudFraudLabsPro\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 11
+			path: catalog/model/extension/fraud/fraudlabspro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudFraudLabsPro\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/fraud/fraudlabspro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudFraudLabsPro\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 46
+			path: catalog/model/extension/fraud/fraudlabspro.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/fraud/fraudlabspro.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/fraud/fraudlabspro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudIp\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/fraud/ip.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudIp\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/fraud/ip.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudIp\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/fraud/ip.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudIp\:\:\$model_account_customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/fraud/ip.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/fraud/ip.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudMaxMind\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/fraud/maxmind.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudMaxMind\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/fraud/maxmind.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionFraudMaxMind\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 43
+			path: catalog/model/extension/fraud/maxmind.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/fraud/maxmind.php
+
+		-
+			message: '#^Function utf8_strtolower not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/fraud/maxmind.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/fraud/maxmind.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModule\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/module.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/module.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModuleLaybuyLayout\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/module/laybuy_layout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModuleLaybuyLayout\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/module/laybuy_layout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModuleLaybuyLayout\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/module/laybuy_layout.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/module/laybuy_layout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModulePPLogin\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/module/pp_login.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModulePPLogin\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/module/pp_login.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModulePPLogin\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/module/pp_login.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModuleSimpleform\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/module/simpleform.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionModuleSimpleform\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/extension/module/simpleform.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/extension/module/simpleform.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 51
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 59
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 14
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$model_account_address\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$model_account_customer_group\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$model_extension_payment_amazon_login_pay\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAmazonLoginPay\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 19
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Function token not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Variable \$xml might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/amazon_login_pay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetAim\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/authorizenet_aim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetAim\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_aim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetAim\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_aim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetAim\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_aim.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_aim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetSim\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/authorizenet_sim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetSim\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_sim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetSim\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_sim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentAuthorizeNetSim\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_sim.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/authorizenet_sim.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBankTransfer\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBankTransfer\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBankTransfer\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBankTransfer\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBankTransfer\:\:\$model_setting_setting\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/bank_transfer.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayHosted\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayHosted\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayHosted\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayHosted\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayHosted\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/extension/payment/bluepay_hosted.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayRedirect\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayRedirect\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayRedirect\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayRedirect\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentBluePayRedirect\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 7
+			path: catalog/model/extension/payment/bluepay_redirect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 27
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardConnect\:\:\$model_extension_payment_cardconnect\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 10
+			path: catalog/model/extension/payment/cardconnect.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardinity\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardinity\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardinity\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardinity\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCardinity\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Call to static method create\(\) on an unknown class Cardinity\\Client\.$#'
+			identifier: class.notFound
+			count: 2
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Class Cardinity\\Exception\\InvalidAttributeValue not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Class Cardinity\\Exception\\Request not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Instantiated class Cardinity\\Method\\Payment\\Create not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Instantiated class Cardinity\\Method\\Payment\\Finalize not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/cardinity.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCheque\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/cheque.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCheque\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cheque.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCheque\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cheque.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCheque\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cheque.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/cheque.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCOD\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cod.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCOD\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/cod.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCOD\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cod.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCOD\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cod.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentCOD\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/cod.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/cod.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$model_catalog_product\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$model_extension_extension\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentDivido\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Call to static method setMerchant\(\) on an unknown class Divido\.$#'
+			identifier: class.notFound
+			count: 2
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: catalog/model/extension/payment/divido.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentEway\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentEway\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentEway\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 26
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentEway\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentEway\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Call to an undefined method ModelExtensionPaymentEway\:\:log\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 9
+			path: catalog/model/extension/payment/eway.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdata\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdata\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdata\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdata\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 25
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdata\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdata\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 11
+			path: catalog/model/extension/payment/firstdata.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionPaymentFirstdataRemote\)\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 15
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 18
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFirstdataRemote\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 6
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Constant VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/firstdata_remote.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFreeCheckout\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/free_checkout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFreeCheckout\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/free_checkout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentFreeCheckout\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/free_checkout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentG2APay\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/g2apay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentG2APay\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/g2apay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentG2APay\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/payment/g2apay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentG2APay\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/g2apay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentG2APay\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/g2apay.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: catalog/model/extension/payment/g2apay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaAccount\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaAccount\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaAccount\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaAccount\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaAccount\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaAccount\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Variable \$country_to_currency might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/model/extension/payment/klarna_account.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaCheckout\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaCheckout\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 41
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to constant EU_BASE_URL on an unknown class Klarna\\Rest\\Transport\\ConnectorInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to constant EU_TEST_BASE_URL on an unknown class Klarna\\Rest\\Transport\\ConnectorInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to constant NA_BASE_URL on an unknown class Klarna\\Rest\\Transport\\ConnectorInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to constant NA_TEST_BASE_URL on an unknown class Klarna\\Rest\\Transport\\ConnectorInterface\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Call to static method create\(\) on an unknown class Klarna\\Rest\\Transport\\Connector\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 10
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Instantiated class Klarna\\Rest\\Checkout\\Order not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Instantiated class Klarna\\Rest\\OrderManagement\\Order not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Parameter \$connector of method ModelExtensionPaymentKlarnaCheckout\:\:omOrderRetrieve\(\) has invalid type Klarna\\Rest\\Transport\\Connector\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Parameter \$connector of method ModelExtensionPaymentKlarnaCheckout\:\:orderCreate\(\) has invalid type Klarna\\Rest\\Transport\\Connector\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Parameter \$connector of method ModelExtensionPaymentKlarnaCheckout\:\:orderRetrieve\(\) has invalid type Klarna\\Rest\\Transport\\Connector\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Parameter \$connector of method ModelExtensionPaymentKlarnaCheckout\:\:orderUpdate\(\) has invalid type Klarna\\Rest\\Transport\\Connector\.$#'
+			identifier: class.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Variable \$base_url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/klarna_checkout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentKlarnaInvoice\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Variable \$country_to_currency might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/klarna_invoice.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionPaymentLaybuy\)\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 28
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$model_account_customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLaybuy\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 13
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Deprecated in PHP 8\.0\: Required parameter \$status follows optional parameter \$data\.$#'
+			identifier: parameter.requiredAfterOptional
+			count: 1
+			path: catalog/model/extension/payment/laybuy.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLiqPay\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/liqpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLiqPay\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/liqpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLiqPay\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/liqpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentLiqPay\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/liqpay.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/liqpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 15
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 60
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$request\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentMastercardPGS\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 11
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Constant VERSION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/mastercard_pgs.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentNOCHEX\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/nochex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentNOCHEX\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/nochex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentNOCHEX\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/nochex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentNOCHEX\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/nochex.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/nochex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayMate\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/paymate.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayMate\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paymate.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayMate\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paymate.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayMate\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paymate.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayMate\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paymate.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/paymate.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayPoint\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/paypoint.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayPoint\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paypoint.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayPoint\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paypoint.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayPoint\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/paypoint.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/paypoint.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayza\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/payza.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayza\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/payza.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayza\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/payza.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPayza\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/payza.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/payza.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPerpetualPayments\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/perpetual_payments.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPerpetualPayments\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/perpetual_payments.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPerpetualPayments\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/perpetual_payments.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPerpetualPayments\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/perpetual_payments.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/perpetual_payments.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPilibaba\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPilibaba\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 21
+			path: catalog/model/extension/payment/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPilibaba\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPilibaba\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pilibaba.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/extension/payment/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionPaymentPPExpress\)\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 21
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 23
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$encryption\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$length\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$model_extension_extension\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPExpress\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 8
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Function utf8_strlen not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Function utf8_strrpos not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: catalog/model/extension/payment/pp_express.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflow\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/pp_payflow.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflow\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_payflow.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflow\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_payflow.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflow\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_payflow.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_payflow.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflowIframe\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/payment/pp_payflow_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflowIframe\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 13
+			path: catalog/model/extension/payment/pp_payflow_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflowIframe\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_payflow_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPayflowIframe\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_payflow_iframe.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: catalog/model/extension/payment/pp_payflow_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPro\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/pp_pro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPro\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_pro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPro\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_pro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPPro\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_pro.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_pro.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPProIframe\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPProIframe\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 17
+			path: catalog/model/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPProIframe\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPProIframe\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: catalog/model/extension/payment/pp_pro_iframe.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPStandard\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/pp_standard.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPStandard\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_standard.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPStandard\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_standard.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPStandard\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_standard.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentPPStandard\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_standard.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/pp_standard.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 47
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$model_account_order\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$model_checkout_recurring\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayDirect\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 21
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Variable \$data might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Variable \$url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/sagepay_direct.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 43
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$model_account_order\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$model_checkout_recurring\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayServer\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 23
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Variable \$data might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Variable \$url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/payment/sagepay_server.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayUS\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/sagepay_us.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayUS\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_us.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayUS\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_us.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSagePayUS\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_us.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/sagepay_us.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingPp\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingPp\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingPp\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 28
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingPp\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingPp\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingPp\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 9
+			path: catalog/model/extension/payment/securetrading_pp.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 18
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSecureTradingWs\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 11
+			path: catalog/model/extension/payment/securetrading_ws.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSkrill\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/skrill.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSkrill\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/skrill.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSkrill\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/skrill.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentSkrill\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/skrill.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/skrill.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentTwoCheckout\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/twocheckout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentTwoCheckout\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/twocheckout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentTwoCheckout\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/twocheckout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentTwoCheckout\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/twocheckout.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/twocheckout.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWebPaymentSoftware\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/payment/web_payment_software.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWebPaymentSoftware\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/web_payment_software.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWebPaymentSoftware\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/web_payment_software.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWebPaymentSoftware\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/web_payment_software.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/payment/web_payment_software.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 33
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$model_checkout_order\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$model_checkout_recurring\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$model_extension_payment_worldpay\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionPaymentWorldpay\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 18
+			path: catalog/model/extension/payment/worldpay.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 21
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingAusPost\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/auspost.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingCitylink\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/citylink.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 36
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$length\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$model_localisation_country\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$model_localisation_zone\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFedex\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Variable \$total_net_charge might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Variable \$weight might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/shipping/fedex.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 14
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFlat\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/flat.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingFree\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/free.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 11
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingItem\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/item.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingLocationBasedShipping\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/location_based_shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 14
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingParcelforce48\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Variable \$insurance might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/model/extension/shipping/parcelforce_48.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPickup\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPickup\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPickup\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPickup\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPickup\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPickup\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/pickup.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPilibaba\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/shipping/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPilibaba\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPilibaba\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPilibaba\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPilibaba\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingPilibaba\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/pilibaba.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 101
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 28
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 13
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingRoyalMail\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Array has 2 duplicate keys with value ''text'' \(''text'', ''text''\)\.$#'
+			identifier: array.duplicateKey
+			count: 1
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/royal_mail.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 47
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 51
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$length\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUps\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/ups.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 54
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 11
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 8
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingUsps\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Variable \$request might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: catalog/model/extension/shipping/usps.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$currency\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$session\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionShippingWeight\:\:\$weight\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/shipping/weight.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalCoupon\)\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalCoupon\)\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalCoupon\)\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalCoupon\)\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalCoupon\)\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCoupon\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCoupon\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCoupon\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCoupon\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 9
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 9
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Variable \$product_data might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/total/coupon.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCredit\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/credit.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCredit\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/credit.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCredit\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/total/credit.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCredit\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/credit.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalCredit\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/credit.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/total/credit.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalHandling\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/handling.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalHandling\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/total/handling.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalHandling\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/handling.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalHandling\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/handling.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalHandling\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/handling.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalKlarnaFee\)\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalKlarnaFee\)\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalKlarnaFee\)\:\:\$model_account_address\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalKlarnaFee\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalKlarnaFee\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalKlarnaFee\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalKlarnaFee\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Variable \$address might not be defined\.$#'
+			identifier: variable.undefined
+			count: 5
+			path: catalog/model/extension/total/klarna_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalLowOrderFee\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/low_order_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalLowOrderFee\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 7
+			path: catalog/model/extension/total/low_order_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalLowOrderFee\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/low_order_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalLowOrderFee\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/low_order_fee.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalLowOrderFee\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/low_order_fee.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalReward\)\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalReward\)\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalReward\)\:\:\$customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalReward\)\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalReward\)\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalReward\)\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalReward\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalReward\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalReward\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalReward\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalReward\:\:\$model_account_customer\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/extension/total/reward.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalShipping\)\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/shipping.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalShipping\)\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalShipping\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/shipping.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalSubTotal\:\:\$cart\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/sub_total.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalSubTotal\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/sub_total.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalSubTotal\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/sub_total.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalSubTotal\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/sub_total.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalTax\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/tax.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalTax\:\:\$tax\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/tax.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalTotal\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/total.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalTotal\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/total.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalTotal\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/total.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalVoucher\)\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalVoucher\)\:\:\$language\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Access to an undefined property \$this\(ModelExtensionTotalVoucher\)\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalVoucher\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalVoucher\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 16
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 10
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Variable \$amount might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: catalog/model/extension/total/voucher.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalVoucherTheme\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/extension/total/voucher_theme.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalVoucherTheme\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 5
+			path: catalog/model/extension/total/voucher_theme.php
+
+		-
+			message: '#^Access to an undefined property ModelExtensionTotalVoucherTheme\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/extension/total/voucher_theme.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 6
+			path: catalog/model/extension/total/voucher_theme.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationCountry\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/country.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationCountry\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/country.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/localisation/country.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationCurrency\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/currency.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationCurrency\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/localisation/currency.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/localisation/currency.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationLanguage\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/language.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationLanguage\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/language.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/localisation/language.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationLocation\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/location.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationLocation\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/localisation/location.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/localisation/location.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationReturnReason\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/return_reason.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationReturnReason\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/localisation/return_reason.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationReturnReason\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/return_reason.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/localisation/return_reason.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationZone\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/zone.php
+
+		-
+			message: '#^Access to an undefined property ModelLocalisationZone\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/localisation/zone.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/localisation/zone.php
+
+		-
+			message: '#^Access to an undefined property ModelSettingApi\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 3
+			path: catalog/model/setting/api.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/setting/api.php
+
+		-
+			message: '#^Access to an undefined property ModelSettingSetting\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 4
+			path: catalog/model/setting/setting.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/setting/setting.php
+
+		-
+			message: '#^Access to an undefined property ModelSettingStore\:\:\$cache\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/setting/store.php
+
+		-
+			message: '#^Access to an undefined property ModelSettingStore\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/setting/store.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: catalog/model/setting/store.php
+
+		-
+			message: '#^Access to an undefined property ModelToolImage\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 37
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Access to an undefined property ModelToolImage\:\:\$log\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Access to an undefined property ModelToolImage\:\:\$url\.$#'
+			identifier: property.notFound
+			count: 10
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 29
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Constant DIR_PUBLIC not found\.$#'
+			identifier: constant.notFound
+			count: 29
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Function utf8_strrpos not found\.$#'
+			identifier: function.notFound
+			count: 3
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Function utf8_substr not found\.$#'
+			identifier: function.notFound
+			count: 3
+			path: catalog/model/tool/image.php
+
+		-
+			message: '#^Access to an undefined property ModelToolMail\:\:\$config\.$#'
+			identifier: property.notFound
+			count: 12
+			path: catalog/model/tool/mail.php
+
+		-
+			message: '#^Access to an undefined property ModelToolMail\:\:\$load\.$#'
+			identifier: property.notFound
+			count: 2
+			path: catalog/model/tool/mail.php
+
+		-
+			message: '#^Access to an undefined property ModelToolOnline\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/tool/online.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/tool/online.php
+
+		-
+			message: '#^Access to an undefined property ModelToolUpload\:\:\$db\.$#'
+			identifier: property.notFound
+			count: 6
+			path: catalog/model/tool/upload.php
+
+		-
+			message: '#^Access to an undefined property ModelToolUpload\:\:\$encryption\.$#'
+			identifier: property.notFound
+			count: 1
+			path: catalog/model/tool/upload.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: catalog/model/tool/upload.php
+
+		-
+			message: '#^Constant DIR_APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/engine/Action.php
+
+		-
+			message: '#^Constant APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/engine/Loader.php
+
+		-
+			message: '#^Constant DIR_APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/engine/Loader.php
+
+		-
+			message: '#^Constant DIR_PUBLIC not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: system/engine/Loader.php
+
+		-
+			message: '#^Constant DIR_SYSTEM not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/engine/Loader.php
+
+		-
+			message: '#^Constant DIR_TEMPLATE not found\.$#'
+			identifier: constant.notFound
+			count: 8
+			path: system/engine/Loader.php
+
+		-
+			message: '#^Variable \$file might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/engine/Loader.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: system/engine/registry.php
+
+		-
+			message: '#^Constant DIR_CONFIG not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/library/ConfigManager.php
+
+		-
+			message: '#^Call to an undefined method Copona\\System\\Library\\Extension\\ExtensionBase\:\:detail\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: system/library/Extension/ExtensionBase.php
+
+		-
+			message: '#^Method Copona\\System\\Library\\Extension\\ExtensionCollection\:\:add\(\) should return \$this\(Copona\\System\\Library\\Extension\\ExtensionCollection\) but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: system/library/Extension/ExtensionCollection.php
+
+		-
+			message: '#^Constant APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: system/library/Extension/ExtensionManager.php
+
+		-
+			message: '#^Constant DIR_PUBLIC not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/Extension/ExtensionManager.php
+
+		-
+			message: '#^Constant PATH_TEMPLATE not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/library/Extension/ExtensionManager.php
+
+		-
+			message: '#^Method Copona\\System\\Library\\Extension\\ExtensionManager\:\:executeOnInit\(\) should return array but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: system/library/Extension/ExtensionManager.php
+
+		-
+			message: '#^Method Copona\\System\\Library\\Extension\\ExtensionManager\:\:findView\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: system/library/Extension/ExtensionManager.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: system/library/Extension/ExtensionManager.php
+
+		-
+			message: '#^Call to an undefined static method Registry\:\:config\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: system/library/Template/Adapters/Twig.php
+
+		-
+			message: '#^Constant DIR_CACHE_PRIVATE not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/Template/Adapters/Twig.php
+
+		-
+			message: '#^Constant DIR_TEMPLATE not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/library/Template/Adapters/Twig.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 5
+			path: system/library/cart/affiliate.php
+
+		-
+			message: '#^Function utf8_strtolower not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: system/library/cart/affiliate.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 31
+			path: system/library/cart/cart.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/cart/currency.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 10
+			path: system/library/cart/customer.php
+
+		-
+			message: '#^Function utf8_strtolower not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: system/library/cart/customer.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/library/cart/length.php
+
+		-
+			message: '#^Access to an undefined property Cart\\Tax\:\:\$taxes\.$#'
+			identifier: property.notFound
+			count: 1
+			path: system/library/cart/tax.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 16
+			path: system/library/cart/tax.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 7
+			path: system/library/cart/user.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/library/cart/weight.php
+
+		-
+			message: '#^Constant DIR_CONFIG not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/config.php
+
+		-
+			message: '#^Access to an undefined property DB\\mPDO\:\:\$rowCount\.$#'
+			identifier: property.notFound
+			count: 3
+			path: system/library/db/mpdo.php
+
+		-
+			message: '#^Access to an undefined property DB\\MSSQL\:\:\$link\.$#'
+			identifier: property.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_close not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_connect not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_fetch_assoc not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_fetch_row not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_free_result not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_get_last_message not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_query not found\.$#'
+			identifier: function.notFound
+			count: 4
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_rows_affected not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mssql_select_db not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/mssql.php
+
+		-
+			message: '#^Function mysql_select_db not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: system/library/db/postgre.php
+
+		-
+			message: '#^Constant DIR_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: system/library/image.php
+
+		-
+			message: '#^Variable \$from_x might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/image.php
+
+		-
+			message: '#^Variable \$from_y might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/image.php
+
+		-
+			message: '#^Variable \$photo_x might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/image.php
+
+		-
+			message: '#^Variable \$photo_y might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/image.php
+
+		-
+			message: '#^Variable \$watermark_pos_x might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: system/library/image.php
+
+		-
+			message: '#^Variable \$watermark_pos_y might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: system/library/image.php
+
+		-
+			message: '#^Constant APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/language.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/language.php
+
+		-
+			message: '#^Constant DIR_LANGUAGE not found\.$#'
+			identifier: constant.notFound
+			count: 6
+			path: system/library/language.php
+
+		-
+			message: '#^Constant DIR_TEMPLATE not found\.$#'
+			identifier: constant.notFound
+			count: 6
+			path: system/library/language.php
+
+		-
+			message: '#^Constant DIR_LOGS not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: system/library/log.php
+
+		-
+			message: '#^Caught class phpmailerException not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: system/library/mail.php
+
+		-
+			message: '#^Array has 2 duplicate keys with value ''Đ'' \(''Đ'', ''Đ''\)\.$#'
+			identifier: array.duplicateKey
+			count: 1
+			path: system/library/seourl.php
+
+		-
+			message: '#^Array has 2 duplicate keys with value ''Ž'' \(''Ž'', ''Ž''\)\.$#'
+			identifier: array.duplicateKey
+			count: 1
+			path: system/library/seourl.php
+
+		-
+			message: '#^Array has 2 duplicate keys with value ''ž'' \(''ž'', ''ž''\)\.$#'
+			identifier: array.duplicateKey
+			count: 1
+			path: system/library/seourl.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 3
+			path: system/library/seourl.php
+
+		-
+			message: '#^Constant DB_PREFIX not found\.$#'
+			identifier: constant.notFound
+			count: 4
+			path: system/library/session/db.php
+
+		-
+			message: '#^Method Session\\File\:\:destroy\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 2
+			path: system/library/session/file.php
+
+		-
+			message: '#^Constant APPLICATION not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: system/library/url.php
+
+		-
+			message: '#^Constant BASE_URL_IMAGE not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: system/library/url.php
+
+		-
+			message: '#^Variable \$ex_link might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/url.php
+
+		-
+			message: '#^Variable \$route might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/url.php
+
+		-
+			message: '#^Variable \$url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: system/library/url.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 1
+    paths:
+        - catalog
+        - system/engine
+        - system/library
+    excludePaths:
+        - vendor
+        - storage
+    treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: false

--- a/system/engine/hook.php
+++ b/system/engine/hook.php
@@ -1,25 +1,29 @@
 <?php
-class Hook {
+
+class Hook
+{
     protected $registry;
-    protected $data = array();
+    protected $data = [];
     private $hooks;
 
-    public function __construct($registry) {
+    public function __construct($registry)
+    {
         $this->registry = $registry;
     }
 
-    public function setHook($string, $data = [ ]) {
+    public function setHook($string, $data = [ ])
+    {
         $this->hooks[$string][] = $data;
     }
 
-    public function getHook($string, &$data = [ ]) {
+    public function getHook($string, &$data = [ ])
+    {
 
         if (!empty($this->hooks[$string])) {
             foreach ($this->hooks[$string] as $function) {
 
-
                 // Ability to pass class object and method.
-                if( gettype($function) == 'array' && method_exists($function[0], $function[1]) ) {
+                if (gettype($function) == 'array' && method_exists($function[0], $function[1])) {
                     $function[0]->{$function[1]}($data, $this->registry);
                 } elseif (is_string($function) && function_exists($function)) {
                     $function($data, $this->registry);
@@ -31,7 +35,8 @@ class Hook {
         }
     }
 
-    public function getHooks() {
+    public function getHooks()
+    {
         return $this->hooks;
     }
 

--- a/system/library/cart/cart.php
+++ b/system/library/cart/cart.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace Cart;
 
-class Cart {
+class Cart
+{
     private $registry;
     private $config;
     private $customer;
@@ -26,7 +28,8 @@ class Cart {
 
     public $cartProducts = [];
 
-    public function __construct($registry) {
+    public function __construct($registry)
+    {
 
         $this->registry = &$registry;
 
@@ -61,13 +64,13 @@ class Cart {
 
         if ($this->customer->getId()) {
             // We want to change the session ID on all the old items in the customers cart
-            $this->db->query("UPDATE " . DB_PREFIX . "cart SET session_id = '" . $this->db->escape($this->session->getId()) . "' WHERE api_id = '0' AND customer_id = '" . (int)$this->customer->getId() . "'");
+            $this->db->query('UPDATE ' . DB_PREFIX . "cart SET session_id = '" . $this->db->escape($this->session->getId()) . "' WHERE api_id = '0' AND customer_id = '" . (int) $this->customer->getId() . "'");
 
             // Once the customer is logged in we want to update the customers cart
-            $cart_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "cart WHERE api_id = '0' AND customer_id = '0' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
+            $cart_query = $this->db->query('SELECT * FROM ' . DB_PREFIX . "cart WHERE api_id = '0' AND customer_id = '0' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
 
             foreach ($cart_query->rows as $cart) {
-                $this->db->query("DELETE FROM " . DB_PREFIX . "cart WHERE cart_id = '" . (int)$cart['cart_id'] . "'");
+                $this->db->query('DELETE FROM ' . DB_PREFIX . "cart WHERE cart_id = '" . (int) $cart['cart_id'] . "'");
 
                 // The advantage of using $this->add is that it will check if the products already exist and increaser the quantity if necessary.
                 $this->add($cart['product_id'], $cart['quantity'], json_decode($cart['option']), $cart['recurring_id']);
@@ -76,39 +79,39 @@ class Cart {
         $this->cartProducts = $this->getProducts(true);
     }
 
-    public function getProducts($update = false) {
+    public function getProducts($update = false)
+    {
 
         if (!$update) {
             return $this->cartProducts;
         }
 
-
-        $product_data = array();
+        $product_data = [];
         $this->dd_count++;
 
-        $cart_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
+        $cart_query = $this->db->query('SELECT * FROM ' . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int) $this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
 
         foreach ($cart_query->rows as $cart) {
             $stock = true;
-            $product_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_store p2s LEFT JOIN " . DB_PREFIX . "product p ON (p2s.product_id = p.product_id) 
-                LEFT JOIN " . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p2s.store_id = '" . (int)$this->config->get('config_store_id') . "' AND p2s.product_id = '" . (int)$cart['product_id'] . "' AND pd.language_id = '" . (int)$this->config->get('config_language_id') . "' AND p.date_available <= NOW() AND p.status = '1'");
+            $product_query = $this->db->query('SELECT * FROM ' . DB_PREFIX . 'product_to_store p2s LEFT JOIN ' . DB_PREFIX . 'product p ON (p2s.product_id = p.product_id) 
+                LEFT JOIN ' . DB_PREFIX . "product_description pd ON (p.product_id = pd.product_id) WHERE p2s.store_id = '" . (int) $this->config->get('config_store_id') . "' AND p2s.product_id = '" . (int) $cart['product_id'] . "' AND pd.language_id = '" . (int) $this->config->get('config_language_id') . "' AND p.date_available <= NOW() AND p.status = '1'");
 
             if ($product_query->num_rows && ($cart['quantity'] > 0)) {
                 $option_price = 0;
                 $option_points = 0;
                 $option_weight = 0;
 
-                $option_data = array();
+                $option_data = [];
 
                 foreach (json_decode($cart['option']) as $product_option_id => $value) {
-                    $option_query = $this->db->query("SELECT po.product_option_id, po.option_id, od.name, od.display, o.type FROM " . DB_PREFIX . "product_option po LEFT JOIN `" . DB_PREFIX . "option` o ON (po.option_id = o.option_id) LEFT JOIN " . DB_PREFIX . "option_description od ON (o.option_id = od.option_id) WHERE po.product_option_id = '" . (int)$product_option_id . "' AND po.product_id = '" . (int)$cart['product_id'] . "' AND od.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                    $option_query = $this->db->query('SELECT po.product_option_id, po.option_id, od.name, od.display, o.type FROM ' . DB_PREFIX . 'product_option po LEFT JOIN `' . DB_PREFIX . 'option` o ON (po.option_id = o.option_id) LEFT JOIN ' . DB_PREFIX . "option_description od ON (o.option_id = od.option_id) WHERE po.product_option_id = '" . (int) $product_option_id . "' AND po.product_id = '" . (int) $cart['product_id'] . "' AND od.language_id = '" . (int) $this->config->get('config_language_id') . "'");
 
                     if ($option_query->num_rows) {
-                        if ($option_query->row['display'] != "") {
+                        if ($option_query->row['display'] != '') {
                             $option_query->row['name'] = $option_query->row['display'];
                         }
                         if ($option_query->row['type'] == 'select' || $option_query->row['type'] == 'radio' || $option_query->row['type'] == 'image') {
-                            $option_value_query = $this->db->query("SELECT pov.option_value_id, ovd.name, pov.quantity, pov.subtract, pov.price, pov.price_prefix, pov.points, pov.points_prefix, pov.weight, pov.weight_prefix FROM " . DB_PREFIX . "product_option_value pov LEFT JOIN " . DB_PREFIX . "option_value ov ON (pov.option_value_id = ov.option_value_id) LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (ov.option_value_id = ovd.option_value_id) WHERE pov.product_option_value_id = '" . (int)$value . "' AND pov.product_option_id = '" . (int)$product_option_id . "' AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                            $option_value_query = $this->db->query('SELECT pov.option_value_id, ovd.name, pov.quantity, pov.subtract, pov.price, pov.price_prefix, pov.points, pov.points_prefix, pov.weight, pov.weight_prefix FROM ' . DB_PREFIX . 'product_option_value pov LEFT JOIN ' . DB_PREFIX . 'option_value ov ON (pov.option_value_id = ov.option_value_id) LEFT JOIN ' . DB_PREFIX . "option_value_description ovd ON (ov.option_value_id = ovd.option_value_id) WHERE pov.product_option_value_id = '" . (int) $value . "' AND pov.product_option_id = '" . (int) $product_option_id . "' AND ovd.language_id = '" . (int) $this->config->get('config_language_id') . "'");
 
                             if ($option_value_query->num_rows) {
                                 if ($option_value_query->row['price_prefix'] == '+') {
@@ -133,37 +136,37 @@ class Cart {
                                     $stock = false;
                                 }
 
-                                $option_data[] = array(
-                                    'product_option_id'       => $product_option_id,
+                                $option_data[] = [
+                                    'product_option_id' => $product_option_id,
                                     'product_option_value_id' => $value,
-                                    'option_id'               => $option_query->row['option_id'],
-                                    'option_value_id'         => $option_value_query->row['option_value_id'],
-                                    'name'                    => $option_query->row['name'],
-                                    'value'                   => $option_value_query->row['name'],
-                                    'type'                    => $option_query->row['type'],
-                                    'quantity'                => $option_value_query->row['quantity'],
-                                    'subtract'                => $option_value_query->row['subtract'],
-                                    'price'                   => $option_value_query->row['price'],
-                                    'price_prefix'            => $option_value_query->row['price_prefix'],
-                                    'points'                  => $option_value_query->row['points'],
-                                    'points_prefix'           => $option_value_query->row['points_prefix'],
-                                    'weight'                  => $option_value_query->row['weight'],
-                                    'weight_prefix'           => $option_value_query->row['weight_prefix']
-                                );
+                                    'option_id' => $option_query->row['option_id'],
+                                    'option_value_id' => $option_value_query->row['option_value_id'],
+                                    'name' => $option_query->row['name'],
+                                    'value' => $option_value_query->row['name'],
+                                    'type' => $option_query->row['type'],
+                                    'quantity' => $option_value_query->row['quantity'],
+                                    'subtract' => $option_value_query->row['subtract'],
+                                    'price' => $option_value_query->row['price'],
+                                    'price_prefix' => $option_value_query->row['price_prefix'],
+                                    'points' => $option_value_query->row['points'],
+                                    'points_prefix' => $option_value_query->row['points_prefix'],
+                                    'weight' => $option_value_query->row['weight'],
+                                    'weight_prefix' => $option_value_query->row['weight_prefix'],
+                                ];
                             }
                         } elseif ($option_query->row['type'] == 'checkbox' && is_array($value)) {
                             foreach ($value as $product_option_value_id) {
-                                $option_value_query = $this->db->query("SELECT pov.option_value_id"
-                                                                       . ", pov.quantity, pov.subtract, pov.price, pov.price_prefix"
-                                                                       . ", pov.points"
-                                                                       . ", pov.points_prefix"
-                                                                       . ", pov.weight"
-                                                                       . ", pov.weight_prefix"
-                                                                       . ", ovd.name FROM " . DB_PREFIX . "product_option_value pov "
-                                                                       . "LEFT JOIN " . DB_PREFIX . "option_value_description ovd ON (pov.option_value_id = ovd.option_value_id) "
-                                                                       . "WHERE pov.product_option_value_id = '" . (int)$product_option_value_id . "' "
-                                                                       . "AND pov.product_option_id = '" . (int)$product_option_id . "' "
-                                                                       . "AND ovd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                                $option_value_query = $this->db->query('SELECT pov.option_value_id'
+                                                                       . ', pov.quantity, pov.subtract, pov.price, pov.price_prefix'
+                                                                       . ', pov.points'
+                                                                       . ', pov.points_prefix'
+                                                                       . ', pov.weight'
+                                                                       . ', pov.weight_prefix'
+                                                                       . ', ovd.name FROM ' . DB_PREFIX . 'product_option_value pov '
+                                                                       . 'LEFT JOIN ' . DB_PREFIX . 'option_value_description ovd ON (pov.option_value_id = ovd.option_value_id) '
+                                                                       . "WHERE pov.product_option_value_id = '" . (int) $product_option_value_id . "' "
+                                                                       . "AND pov.product_option_id = '" . (int) $product_option_id . "' "
+                                                                       . "AND ovd.language_id = '" . (int) $this->config->get('config_language_id') . "'");
 
                                 if ($option_value_query->num_rows) {
                                     if ($option_value_query->row['price_prefix'] == '+') {
@@ -188,23 +191,23 @@ class Cart {
                                         $stock = false;
                                     }
 
-                                    $option_data[] = array(
-                                        'product_option_id'       => $product_option_id,
+                                    $option_data[] = [
+                                        'product_option_id' => $product_option_id,
                                         'product_option_value_id' => $product_option_value_id,
-                                        'option_id'               => $option_query->row['option_id'],
-                                        'option_value_id'         => $option_value_query->row['option_value_id'],
-                                        'name'                    => $option_query->row['name'],
-                                        'value'                   => $option_value_query->row['name'],
-                                        'type'                    => $option_query->row['type'],
-                                        'quantity'                => $option_value_query->row['quantity'],
-                                        'subtract'                => $option_value_query->row['subtract'],
-                                        'price'                   => $option_value_query->row['price'],
-                                        'price_prefix'            => $option_value_query->row['price_prefix'],
-                                        'points'                  => $option_value_query->row['points'],
-                                        'points_prefix'           => $option_value_query->row['points_prefix'],
-                                        'weight'                  => $option_value_query->row['weight'],
-                                        'weight_prefix'           => $option_value_query->row['weight_prefix']
-                                    );
+                                        'option_id' => $option_query->row['option_id'],
+                                        'option_value_id' => $option_value_query->row['option_value_id'],
+                                        'name' => $option_query->row['name'],
+                                        'value' => $option_value_query->row['name'],
+                                        'type' => $option_query->row['type'],
+                                        'quantity' => $option_value_query->row['quantity'],
+                                        'subtract' => $option_value_query->row['subtract'],
+                                        'price' => $option_value_query->row['price'],
+                                        'price_prefix' => $option_value_query->row['price_prefix'],
+                                        'points' => $option_value_query->row['points'],
+                                        'points_prefix' => $option_value_query->row['points_prefix'],
+                                        'weight' => $option_value_query->row['weight'],
+                                        'weight_prefix' => $option_value_query->row['weight_prefix'],
+                                    ];
                                 }
                             }
                         } elseif ($option_query->row['type'] == 'text'
@@ -213,29 +216,28 @@ class Cart {
                                   || $option_query->row['type'] == 'date'
                                   || $option_query->row['type'] == 'datetime'
                                   || $option_query->row['type'] == 'time') {
-                            $option_data[] = array(
-                                'product_option_id'       => $product_option_id,
+                            $option_data[] = [
+                                'product_option_id' => $product_option_id,
                                 'product_option_value_id' => '',
-                                'option_id'               => $option_query->row['option_id'],
-                                'option_value_id'         => '',
-                                'name'                    => $option_query->row['name'],
-                                'value'                   => $value,
-                                'type'                    => $option_query->row['type'],
-                                'quantity'                => '',
-                                'subtract'                => '',
-                                'price'                   => '',
-                                'price_prefix'            => '',
-                                'points'                  => '',
-                                'points_prefix'           => '',
-                                'weight'                  => '',
-                                'weight_prefix'           => ''
-                            );
+                                'option_id' => $option_query->row['option_id'],
+                                'option_value_id' => '',
+                                'name' => $option_query->row['name'],
+                                'value' => $value,
+                                'type' => $option_query->row['type'],
+                                'quantity' => '',
+                                'subtract' => '',
+                                'price' => '',
+                                'price_prefix' => '',
+                                'points' => '',
+                                'points_prefix' => '',
+                                'weight' => '',
+                                'weight_prefix' => '',
+                            ];
                         }
                     }
                 }
 
                 $price = $product_query->row['price'];
-
 
                 // Product Discounts
                 $discount_quantity = 0;
@@ -246,11 +248,11 @@ class Cart {
                     }
                 }
 
-                $product_discount_query = $this->db->query("SELECT price FROM " . DB_PREFIX . "product_discount 
+                $product_discount_query = $this->db->query('SELECT price FROM ' . DB_PREFIX . "product_discount 
                 WHERE true 
-                AND product_id = '" . (int)$cart['product_id'] . "' 
-                AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' 
-                AND quantity <= '" . (int)$discount_quantity . "' 
+                AND product_id = '" . (int) $cart['product_id'] . "' 
+                AND customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "' 
+                AND quantity <= '" . (int) $discount_quantity . "' 
                 AND ((date_start = '0000-00-00' OR date_start < NOW()) AND (date_end = '0000-00-00' OR date_end > NOW())) 
                 ORDER BY quantity DESC, priority ASC, price ASC LIMIT 1");
 
@@ -259,10 +261,10 @@ class Cart {
                 }
 
                 // Product Specials
-                $product_special_query = $this->db->query("SELECT price FROM " . DB_PREFIX . "product_special 
+                $product_special_query = $this->db->query('SELECT price FROM ' . DB_PREFIX . "product_special 
                 WHERE true 
-                AND product_id = '" . (int)$cart['product_id'] . "' 
-                AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' 
+                AND product_id = '" . (int) $cart['product_id'] . "' 
+                AND customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "' 
                 AND ((date_start IS NULL OR date_start < NOW()) AND (date_end IS NULL OR date_end > NOW())) 
                 ORDER BY priority ASC, price ASC LIMIT 1");
 
@@ -271,10 +273,10 @@ class Cart {
                 }
 
                 // Reward Points
-                $product_reward_query = $this->db->query("SELECT points FROM " . DB_PREFIX . "product_reward 
+                $product_reward_query = $this->db->query('SELECT points FROM ' . DB_PREFIX . "product_reward 
                 WHERE true 
-                AND product_id = '" . (int)$cart['product_id'] . "' 
-                AND customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
+                AND product_id = '" . (int) $cart['product_id'] . "' 
+                AND customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "'");
 
                 if ($product_reward_query->num_rows) {
                     $reward = $product_reward_query->row['points'];
@@ -282,19 +284,18 @@ class Cart {
                     $reward = 0;
                 }
 
-
                 // Downloads
-                $download_data = array();
+                $download_data = [];
 
-                $download_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "product_to_download p2d LEFT JOIN " . DB_PREFIX . "download d ON (p2d.download_id = d.download_id) LEFT JOIN " . DB_PREFIX . "download_description dd ON (d.download_id = dd.download_id) WHERE p2d.product_id = '" . (int)$cart['product_id'] . "' AND dd.language_id = '" . (int)$this->config->get('config_language_id') . "'");
+                $download_query = $this->db->query('SELECT * FROM ' . DB_PREFIX . 'product_to_download p2d LEFT JOIN ' . DB_PREFIX . 'download d ON (p2d.download_id = d.download_id) LEFT JOIN ' . DB_PREFIX . "download_description dd ON (d.download_id = dd.download_id) WHERE p2d.product_id = '" . (int) $cart['product_id'] . "' AND dd.language_id = '" . (int) $this->config->get('config_language_id') . "'");
 
                 foreach ($download_query->rows as $download) {
-                    $download_data[] = array(
+                    $download_data[] = [
                         'download_id' => $download['download_id'],
-                        'name'        => $download['name'],
-                        'filename'    => $download['filename'],
-                        'mask'        => $download['mask']
-                    );
+                        'name' => $download['name'],
+                        'filename' => $download['filename'],
+                        'mask' => $download['mask'],
+                    ];
                 }
 
                 // Stock: only check quantity when the product subtracts from inventory
@@ -302,42 +303,47 @@ class Cart {
                     $stock = false;
                 }
 
-                $recurring_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "recurring r LEFT JOIN " . DB_PREFIX . "product_recurring pr ON (r.recurring_id = pr.recurring_id) LEFT JOIN " . DB_PREFIX . "recurring_description rd ON (r.recurring_id = rd.recurring_id) WHERE r.recurring_id = '" . (int)$cart['recurring_id'] . "' AND pr.product_id = '" . (int)$cart['product_id'] . "' AND rd.language_id = " . (int)$this->config->get('config_language_id') . " AND r.status = 1 AND pr.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "'");
+                $recurring_query = $this->db->query('SELECT * FROM ' . DB_PREFIX . 'recurring r LEFT JOIN ' . DB_PREFIX . 'product_recurring pr ON (r.recurring_id = pr.recurring_id) LEFT JOIN ' . DB_PREFIX . "recurring_description rd ON (r.recurring_id = rd.recurring_id) WHERE r.recurring_id = '" . (int) $cart['recurring_id'] . "' AND pr.product_id = '" . (int) $cart['product_id'] . "' AND rd.language_id = " . (int) $this->config->get('config_language_id') . " AND r.status = 1 AND pr.customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "'");
 
                 if ($recurring_query->num_rows) {
-                    $recurring = array(
-                        'recurring_id'    => $cart['recurring_id'],
-                        'name'            => $recurring_query->row['name'],
-                        'frequency'       => $recurring_query->row['frequency'],
-                        'price'           => $recurring_query->row['price'],
-                        'cycle'           => $recurring_query->row['cycle'],
-                        'duration'        => $recurring_query->row['duration'],
-                        'trial'           => $recurring_query->row['trial_status'],
+                    $recurring = [
+                        'recurring_id' => $cart['recurring_id'],
+                        'name' => $recurring_query->row['name'],
+                        'frequency' => $recurring_query->row['frequency'],
+                        'price' => $recurring_query->row['price'],
+                        'cycle' => $recurring_query->row['cycle'],
+                        'duration' => $recurring_query->row['duration'],
+                        'trial' => $recurring_query->row['trial_status'],
                         'trial_frequency' => $recurring_query->row['trial_frequency'],
-                        'trial_price'     => $recurring_query->row['trial_price'],
-                        'trial_cycle'     => $recurring_query->row['trial_cycle'],
-                        'trial_duration'  => $recurring_query->row['trial_duration']
-                    );
+                        'trial_price' => $recurring_query->row['trial_price'],
+                        'trial_cycle' => $recurring_query->row['trial_cycle'],
+                        'trial_duration' => $recurring_query->row['trial_duration'],
+                    ];
                 } else {
                     $recurring = false;
                 }
 
-
                 // TODO: CUSTOM MOD: for EAN value - NOT FOR PRODUCTION!
                 // also in catalog/model/product/product.php
-                if ((double)$product_query->row['ean']) {
-                    $ean = $this->tax->calculate($product_query->row['ean'],
-                        $this->config->get('flat_per_product_tax_class_id'), $this->config->get('config_tax'));
+                if ((float) $product_query->row['ean']) {
+                    $ean = $this->tax->calculate(
+                        $product_query->row['ean'],
+                        $this->config->get('flat_per_product_tax_class_id'),
+                        $this->config->get('config_tax')
+                    );
                 } else {
                     $ean = $product_query->row['ean'];
                 }
 
-
                 // TODO: check in common/cart.php controller!
                 // We need product price + option price for opened product.
                 $price_enduser = $this->currency->format($this->tax->calculate($price, $product_query->row['tax_class_id'], $this->config->get('config_tax')), '', '', false)
-                                 + $this->currency->format($this->tax->calculate($option_price, $product_query->row['tax_class_id'], $this->config->get('config_tax')), '', '',
-                        false);
+                                 + $this->currency->format(
+                                     $this->tax->calculate($option_price, $product_query->row['tax_class_id'], $this->config->get('config_tax')),
+                                     '',
+                                     '',
+                                     false
+                                 );
                 $price_enduser_total = $price_enduser * $cart['quantity'];
 
                 $price_enduser_formatted = $this->currency->format2($price_enduser);
@@ -354,56 +360,63 @@ class Cart {
                 $tax = $price_enduser_total - $price_total;
 
                 if ($product_query->row['image']) {
-                    $thumb = $this->registry->get('model_tool_image')->{$this->config->get('theme_default_image_cart_resize', 'resize')}($product_query->row['image'],
+                    $thumb = $this->registry->get('model_tool_image')->{$this->config->get('theme_default_image_cart_resize', 'resize')}(
+                        $product_query->row['image'],
                         $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
-                        $this->config->get($this->config->get('config_theme') . '_image_cart_height'));
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_height')
+                    );
                 } else {
-                    $thumb = $this->registry->get('model_tool_image')->{$this->config->get('theme_default_image_cart_resize', 'resize')}($this->config->get('config_no_image',
-                        'placeholder.png'), $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
-                        $this->config->get($this->config->get('config_theme') . '_image_cart_height'));
+                    $thumb = $this->registry->get('model_tool_image')->{$this->config->get('theme_default_image_cart_resize', 'resize')}(
+                        $this->config->get(
+                            'config_no_image',
+                            'placeholder.png'
+                        ),
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_width'),
+                        $this->config->get($this->config->get('config_theme') . '_image_cart_height')
+                    );
                 }
 
-                $href = $this->registry->get('url')->link('product/product','product_id=' . $product_query->row['product_id']);
+                $href = $this->registry->get('url')->link('product/product', 'product_id=' . $product_query->row['product_id']);
 
-                $product_data[] = array(
-                    'cart_id'                       => $cart['cart_id'],
-                    'product_id'                    => $product_query->row['product_id'],
-                    'name'                          => $product_query->row['name'],
-                    'model'                         => $product_query->row['model'],
-                    'shipping'                      => $product_query->row['shipping'],
-                    'image'                         => $product_query->row['image'],
-                    'thumb'                         => $thumb,
-                    'href'                          => $href,
-                    'option'                        => $option_data,
-                    'ean'                           => $ean,
-                    'download'                      => $download_data,
-                    'quantity'                      => $cart['quantity'],
-                    'minimum'                       => $product_query->row['minimum'],
-                    'subtract'                      => $product_query->row['subtract'],
-                    'stock'                         => $stock,
-                    'price'                         => $price,
-                    'total'                         => $price_total,
-                    'content_meta'                  => $this->registry->get('model_catalog_content')->getContentMeta($product_query->row['product_id'], 'product'),
-                    'tax'                           => $tax,
-                    'tax_amount'                    => $tax_amount / $cart['quantity'], // Do not ROUND and FORMAT!
-                    'tax_amount_total'              => $tax_amount,
-                    'price_without_tax'             => ($price_enduser_total - $tax_amount) / $cart['quantity'],
-                    'total_without_tax'             => $price_enduser_total - $tax_amount,
-                    'price_enduser'                 => $price_enduser,
-                    'price_enduser_formatted'       => $price_enduser_formatted,
-                    'price_enduser_total'           => $price_enduser_total,
+                $product_data[] = [
+                    'cart_id' => $cart['cart_id'],
+                    'product_id' => $product_query->row['product_id'],
+                    'name' => $product_query->row['name'],
+                    'model' => $product_query->row['model'],
+                    'shipping' => $product_query->row['shipping'],
+                    'image' => $product_query->row['image'],
+                    'thumb' => $thumb,
+                    'href' => $href,
+                    'option' => $option_data,
+                    'ean' => $ean,
+                    'download' => $download_data,
+                    'quantity' => $cart['quantity'],
+                    'minimum' => $product_query->row['minimum'],
+                    'subtract' => $product_query->row['subtract'],
+                    'stock' => $stock,
+                    'price' => $price,
+                    'total' => $price_total,
+                    'content_meta' => $this->registry->get('model_catalog_content')->getContentMeta($product_query->row['product_id'], 'product'),
+                    'tax' => $tax,
+                    'tax_amount' => $tax_amount / $cart['quantity'], // Do not ROUND and FORMAT!
+                    'tax_amount_total' => $tax_amount,
+                    'price_without_tax' => ($price_enduser_total - $tax_amount) / $cart['quantity'],
+                    'total_without_tax' => $price_enduser_total - $tax_amount,
+                    'price_enduser' => $price_enduser,
+                    'price_enduser_formatted' => $price_enduser_formatted,
+                    'price_enduser_total' => $price_enduser_total,
                     'price_enduser_total_formatted' => $price_enduser_total_formatted,
-                    'reward'                        => $reward * $cart['quantity'],
-                    'points'                        => ($product_query->row['points'] ? ($product_query->row['points'] + $option_points) * $cart['quantity'] : 0),
-                    'tax_class_id'                  => $product_query->row['tax_class_id'],
-                    'weight'                        => ($product_query->row['weight'] + $option_weight) * $cart['quantity'],
-                    'weight_class_id'               => $product_query->row['weight_class_id'],
-                    'length'                        => $product_query->row['length'],
-                    'width'                         => $product_query->row['width'],
-                    'height'                        => $product_query->row['height'],
-                    'length_class_id'               => $product_query->row['length_class_id'],
-                    'recurring'                     => $recurring
-                );
+                    'reward' => $reward * $cart['quantity'],
+                    'points' => ($product_query->row['points'] ? ($product_query->row['points'] + $option_points) * $cart['quantity'] : 0),
+                    'tax_class_id' => $product_query->row['tax_class_id'],
+                    'weight' => ($product_query->row['weight'] + $option_weight) * $cart['quantity'],
+                    'weight_class_id' => $product_query->row['weight_class_id'],
+                    'length' => $product_query->row['length'],
+                    'width' => $product_query->row['width'],
+                    'height' => $product_query->row['height'],
+                    'length_class_id' => $product_query->row['length_class_id'],
+                    'recurring' => $recurring,
+                ];
 
             } else {
                 $this->remove($cart['cart_id']);
@@ -415,40 +428,45 @@ class Cart {
         return $product_data;
     }
 
-    public function add($product_id, $quantity = 1, $option = array(), $recurring_id = 0) {
-        $query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "' AND product_id = '" . (int)$product_id . "' AND recurring_id = '" . (int)$recurring_id . "' AND `option` = '" . $this->db->escape(json_encode($option)) . "'");
+    public function add($product_id, $quantity = 1, $option = [], $recurring_id = 0)
+    {
+        $query = $this->db->query('SELECT COUNT(*) AS total FROM ' . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int) $this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "' AND product_id = '" . (int) $product_id . "' AND recurring_id = '" . (int) $recurring_id . "' AND `option` = '" . $this->db->escape(json_encode($option)) . "'");
 
         if (!$query->row['total']) {
 
-            $sql = "INSERT " . DB_PREFIX . "cart SET api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "', 
-customer_id = '" . (int)$this->customer->getId() . "', session_id = '" . $this->db->escape($this->session->getId()) . "', 
-product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id . "', 
-`option` = '" . $this->db->escape(json_encode($option)) . "', quantity = '" . (int)$quantity . "', date_added = NOW()";
+            $sql = 'INSERT ' . DB_PREFIX . "cart SET api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "', 
+customer_id = '" . (int) $this->customer->getId() . "', session_id = '" . $this->db->escape($this->session->getId()) . "', 
+product_id = '" . (int) $product_id . "', recurring_id = '" . (int) $recurring_id . "', 
+`option` = '" . $this->db->escape(json_encode($option)) . "', quantity = '" . (int) $quantity . "', date_added = NOW()";
             $this->db->query($sql);
         } else {
-            $sql = "UPDATE " . DB_PREFIX . "cart SET quantity = (quantity + " . (int)$quantity . ") WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "' AND product_id = '" . (int)$product_id . "' AND recurring_id = '" . (int)$recurring_id . "' AND `option` = '" . $this->db->escape(json_encode($option)) . "'";
+            $sql = 'UPDATE ' . DB_PREFIX . 'cart SET quantity = (quantity + ' . (int) $quantity . ") WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int) $this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "' AND product_id = '" . (int) $product_id . "' AND recurring_id = '" . (int) $recurring_id . "' AND `option` = '" . $this->db->escape(json_encode($option)) . "'";
             $this->db->query($sql);
         }
         $this->cartProducts = $this->getProducts(true);
     }
 
-    public function update($cart_id, $quantity) {
-        $this->db->query("UPDATE " . DB_PREFIX . "cart SET quantity = '" . (int)$quantity . "' WHERE cart_id = '" . (int)$cart_id . "' AND api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
+    public function update($cart_id, $quantity)
+    {
+        $this->db->query('UPDATE ' . DB_PREFIX . "cart SET quantity = '" . (int) $quantity . "' WHERE cart_id = '" . (int) $cart_id . "' AND api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int) $this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
         $this->cartProducts = $this->getProducts(true);
     }
 
-    public function remove($cart_id) {
-        $this->db->query("DELETE FROM " . DB_PREFIX . "cart WHERE cart_id = '" . (int)$cart_id . "' AND api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
+    public function remove($cart_id)
+    {
+        $this->db->query('DELETE FROM ' . DB_PREFIX . "cart WHERE cart_id = '" . (int) $cart_id . "' AND api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int) $this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
         $this->cartProducts = $this->getProducts(true);
     }
 
-    public function clear() {
-        $this->db->query("DELETE FROM " . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int)$this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int)$this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
+    public function clear()
+    {
+        $this->db->query('DELETE FROM ' . DB_PREFIX . "cart WHERE api_id = '" . (isset($this->session->data['api_id']) ? (int) $this->session->data['api_id'] : 0) . "' AND customer_id = '" . (int) $this->customer->getId() . "' AND session_id = '" . $this->db->escape($this->session->getId()) . "'");
         $this->cartProducts = $this->getProducts(true);
     }
 
-    public function getRecurringProducts() {
-        $product_data = array();
+    public function getRecurringProducts()
+    {
+        $product_data = [];
 
         foreach ($this->cartProducts as $value) {
             if ($value['recurring']) {
@@ -459,7 +477,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return $product_data;
     }
 
-    public function getWeight() {
+    public function getWeight()
+    {
         $weight = 0;
 
         foreach ($this->cartProducts as $product) {
@@ -471,7 +490,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return $weight;
     }
 
-    public function getSubTotal() {
+    public function getSubTotal()
+    {
         $total = 0;
         foreach ($this->cartProducts as $product) {
             //TODO: dirty workaround for free_product gift - bezmaksas produkts.
@@ -481,7 +501,6 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
 
             $total += $product['price_enduser_total'];
         }
-
 
         foreach ($this->getTaxes() as $tax) {
             $total -= $tax;
@@ -514,8 +533,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return $tax_data;
     } */
 
-
-    public function getTaxes() {
+    public function getTaxes()
+    {
         $tax = [];
         $enduser_prices = [];
         foreach ($this->cartProducts as $product) {
@@ -544,7 +563,6 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
             }
         }
 
-
         // ROund every total value.
         array_walk($tax, function (&$val) {
             $val = round($val, $this->decimal_places);
@@ -552,8 +570,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return $tax;
     }
 
-
-    public function getTotal() {
+    public function getTotal()
+    {
         $total = 0;
         foreach ($this->cartProducts as $product) {
             // $total += $this->tax->calculate($product['total'], $product['tax_class_id'], $this->config->get('config_tax'));
@@ -562,12 +580,14 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return $total;
     }
 
-    public function getShipping() {
+    public function getShipping()
+    {
         $this->getTotals_azon();
         return $this->shipping;
     }
 
-    public function countProducts($product_id = false) {
+    public function countProducts($product_id = false)
+    {
         $product_total = 0;
 
         $products = $this->cartProducts;
@@ -586,15 +606,18 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return $product_total;
     }
 
-    public function hasProducts() {
+    public function hasProducts()
+    {
         return count($this->cartProducts);
     }
 
-    public function hasRecurringProducts() {
+    public function hasRecurringProducts()
+    {
         return count($this->getRecurringProducts());
     }
 
-    public function hasStock() {
+    public function hasStock()
+    {
         foreach ($this->cartProducts as $product) {
             if (!$product['stock']) {
                 return false;
@@ -604,7 +627,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return true;
     }
 
-    public function hasShipping() {
+    public function hasShipping()
+    {
         foreach ($this->cartProducts as $product) {
             if ($product['shipping']) {
                 return true;
@@ -614,7 +638,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return false;
     }
 
-    public function hasDownload() {
+    public function hasDownload()
+    {
         foreach ($this->cartProducts as $product) {
             if ($product['download']) {
                 return true;
@@ -624,14 +649,14 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
         return false;
     }
 
-
     /*
     TODO: This is needed to generate Currencies array
     to format data according to this.
     */
-    private function cur_constr() {
+    private function cur_constr()
+    {
 
-        $sql = "SELECT * FROM " . DB_PREFIX . "currency where true ";
+        $sql = 'SELECT * FROM ' . DB_PREFIX . 'currency where true ';
 
         $cache_key = 'currency.' . md5($sql);
         $result_data = $this->cache->get($cache_key);
@@ -647,18 +672,17 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
             $this->cache->set($cache_key, $result_data);
         }
 
-
         // $query = $this->db->query($sql);
 
         foreach ($result_data as $result) {
-            $this->currencies[$result['code']] = array(
-                'currency_id'   => $result['currency_id'],
-                'title'         => $result['title'],
-                'symbol_left'   => $result['symbol_left'],
-                'symbol_right'  => $result['symbol_right'],
+            $this->currencies[$result['code']] = [
+                'currency_id' => $result['currency_id'],
+                'title' => $result['title'],
+                'symbol_left' => $result['symbol_left'],
+                'symbol_right' => $result['symbol_right'],
                 'decimal_place' => $result['decimal_place'],
-                'value'         => $result['value']
-            );
+                'value' => $result['value'],
+            ];
         }
         if (isset($this->request->get['currency']) && (array_key_exists($this->request->get['currency'], $this->currencies))) {
             $this->code = $this->request->get['currency'];
@@ -672,27 +696,29 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
 
     }
 
-    public function getTotals($par = []) {
+    public function getTotals($par = [])
+    {
         return $this->getTotals_azon($par);
     }
 
-    public function getTotals_azon($params = []) {
+    public function getTotals_azon($params = [])
+    {
         $data = [];
         $total = 0;
         $taxes = $this->getTaxes();
 
         $totals = [];
-        $total_data = array(
+        $total_data = [
             'totals' => &$totals,
-            'taxes'  => &$taxes,
-            'total'  => &$total
-        );
+            'taxes' => &$taxes,
+            'total' => &$total,
+        ];
 
         $this->cartTotal = 0;
         $this->shipping = 0;
 
         if (($this->config->get('config_customer_price') && $this->customer->isLogged()) || !$this->config->get('config_customer_price')) {
-            $sort_order = array();
+            $sort_order = [];
             $results = $this->extension->getExtensions('total');
             foreach ($results as $key => $value) {
                 $sort_order[$key] = $this->config->get($value['code'] . '_sort_order');
@@ -719,15 +745,17 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
 
                 $this->shipping += $total['code'] == 'shipping' ? $total['value'] : 0;
 
-                $data['totals'][] = array(
-                    'code'       => $total['code'],
-                    'title'      => $total['title'],
+                $data['totals'][] = [
+                    'code' => $total['code'],
+                    'title' => $total['title'],
                     // We need to covert between currencies, to set correct number
-                    'value'      => $total['code'] == 'total' ? $this->currency->convert($this->cartTotal, $this->session->data['currency'], 1) : $total['value'],
+                    'value' => $total['code'] == 'total' ? $this->currency->convert($this->cartTotal, $this->session->data['currency'], 1) : $total['value'],
                     'sort_order' => $total['sort_order'],
-                    'text'       => $total['code'] == 'total' ? $this->currency->format2($this->cartTotal) : $this->currency->format($total['value'],
-                        $this->session->data['currency']),
-                );
+                    'text' => $total['code'] == 'total' ? $this->currency->format2($this->cartTotal) : $this->currency->format(
+                        $total['value'],
+                        $this->session->data['currency']
+                    ),
+                ];
 
             }
         }
@@ -738,7 +766,8 @@ product_id = '" . (int)$product_id . "', recurring_id = '" . (int)$recurring_id 
      * Correct Total with discount
      * @return int
      */
-    public function getCartTotal($format = false) {
+    public function getCartTotal($format = false)
+    {
         // Thus function generates cart total! Together with correct totals built.
         $this->getTotals_azon();
 

--- a/system/library/cart/currency.php
+++ b/system/library/cart/currency.php
@@ -2,7 +2,8 @@
 
 namespace Cart;
 
-class Currency {
+class Currency
+{
     private $config;
     private $db;
     private $language;
@@ -12,7 +13,8 @@ class Currency {
     private $code;
     private $log;
 
-    public function __construct($registry) {
+    public function __construct($registry)
+    {
         $this->config = $registry->get('config');
         $this->db = $registry->get('db');
         $this->language = $registry->get('language');
@@ -23,21 +25,22 @@ class Currency {
 
         $this->log = new \Log('currency_format.log');
 
-        $query = $this->db->query("SELECT * FROM " . DB_PREFIX . "currency");
+        $query = $this->db->query('SELECT * FROM ' . DB_PREFIX . 'currency');
 
         foreach ($query->rows as $result) {
-            $this->currencies[$result['code']] = array(
-              'currency_id'   => $result['currency_id'],
-              'title'         => $result['title'],
-              'symbol_left'   => $result['symbol_left'],
-              'symbol_right'  => $result['symbol_right'],
+            $this->currencies[$result['code']] = [
+              'currency_id' => $result['currency_id'],
+              'title' => $result['title'],
+              'symbol_left' => $result['symbol_left'],
+              'symbol_right' => $result['symbol_right'],
               'decimal_place' => $result['decimal_place'],
-              'value'         => $result['value']
-            );
+              'value' => $result['value'],
+            ];
         }
     }
 
-    public function format2($number, $currency = '') {
+    public function format2($number, $currency = '')
+    {
         // Format with currency rate 1 without rounding!
         return $this->format($number, $currency, 1, true, false);
     }
@@ -46,7 +49,8 @@ class Currency {
      * Function, which just FORMATS the number, without any needless calculations.
      */
 
-    public function format($number, $currency = '', $value = '', $format = true, $round = true) {
+    public function format($number, $currency = '', $value = '', $format = true, $round = true)
+    {
 
         if (!$currency) {
             $currency = $this->code;
@@ -65,8 +69,8 @@ class Currency {
             $value = $this->currencies[$currency]['value'];
         }
 
-        $amount = $value ? (float)$number * $value : (float)$number;
-        $amount = round($amount, (int)$decimal_place);
+        $amount = $value ? (float) $number * $value : (float) $number;
+        $amount = round($amount, (int) $decimal_place);
 
         if (!$format) {
             return $amount;
@@ -78,17 +82,17 @@ class Currency {
             $string .= $symbol_left;
         }
 
-        $string .= number_format($amount, (int)$decimal_place, $this->language->get('decimal_point'), $this->language->get('thousand_point'));
+        $string .= number_format($amount, (int) $decimal_place, $this->language->get('decimal_point'), $this->language->get('thousand_point'));
 
         if ($symbol_right) {
             $string .= $symbol_right;
         }
 
-
         return $string;
     }
 
-    public function convert($value, $from, $to) {
+    public function convert($value, $from, $to)
+    {
         if (isset($this->currencies[$from])) {
             $from = $this->currencies[$from]['value'];
         } else {
@@ -104,7 +108,8 @@ class Currency {
         return $value * ($to / $from);
     }
 
-    public function getId($currency = '') {
+    public function getId($currency = '')
+    {
         if (!$currency) {
             return $this->currencies[$this->code]['currency_id'];
         } elseif ($currency && isset($this->currencies[$currency])) {
@@ -114,7 +119,8 @@ class Currency {
         }
     }
 
-    public function getSymbolLeft($currency = '') {
+    public function getSymbolLeft($currency = '')
+    {
         if (!$currency) {
             return $this->currencies[$this->code]['symbol_left'];
         } elseif ($currency && isset($this->currencies[$currency])) {
@@ -124,7 +130,8 @@ class Currency {
         }
     }
 
-    public function getSymbolRight($currency = '') {
+    public function getSymbolRight($currency = '')
+    {
         if (!$currency) {
             return $this->currencies[$this->code]['symbol_right'];
         } elseif ($currency && isset($this->currencies[$currency])) {
@@ -134,7 +141,8 @@ class Currency {
         }
     }
 
-    public function getDecimalPlace($currency = '') {
+    public function getDecimalPlace($currency = '')
+    {
         if (!$currency) {
             return $this->currencies[$this->code]['decimal_place'];
         } elseif ($currency && isset($this->currencies[$currency])) {
@@ -144,11 +152,13 @@ class Currency {
         }
     }
 
-    public function getCode() {
+    public function getCode()
+    {
         return $this->code;
     }
 
-    public function getValue($currency = '') {
+    public function getValue($currency = '')
+    {
         if (!$currency) {
             return $this->currencies[$this->code]['value'];
         } elseif ($currency && isset($this->currencies[$currency])) {
@@ -158,7 +168,8 @@ class Currency {
         }
     }
 
-    public function has($currency) {
+    public function has($currency)
+    {
         return isset($this->currencies[$currency]);
     }
 }

--- a/system/library/cart/tax.php
+++ b/system/library/cart/tax.php
@@ -1,15 +1,18 @@
 <?php
+
 namespace Cart;
 
-final class Tax {
+final class Tax
+{
     private $config;
     private $db;
     private $session;
     private $currency;
     private $log;
-    private $tax_rates = array();
+    private $tax_rates = [];
 
-    public function __construct($registry) {
+    public function __construct($registry)
+    {
         $this->config = $registry->get('config');
         $this->db = $registry->get('db');
         $this->session = $registry->get('session');
@@ -25,76 +28,81 @@ final class Tax {
 
     // TODO: Is this used at all?
 
-    public function setShippingAddress($country_id, $zone_id) {
+    public function setShippingAddress($country_id, $zone_id)
+    {
 
-        $sql = "SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1
-        LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) 
-        INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) 
-        LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) 
-        LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) 
+        $sql = 'SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM ' . DB_PREFIX . 'tax_rule tr1
+        LEFT JOIN ' . DB_PREFIX . 'tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) 
+        INNER JOIN ' . DB_PREFIX . 'tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) 
+        LEFT JOIN ' . DB_PREFIX . 'zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) 
+        LEFT JOIN ' . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) 
         WHERE tr1.based = 'shipping' 
-        AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' 
-        AND z2gz.country_id = '" . (int)$country_id . "' 
+        AND tr2cg.customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "' 
+        AND z2gz.country_id = '" . (int) $country_id . "' 
 		ORDER BY tr1.priority ASC";
         // TODO: Do we need: AND tr1.based = 'shipping' ?
 
         $tax_query = $this->db->query($sql);
 
         foreach ($tax_query->rows as $result) {
-            $this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
+            $this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = [
               'tax_rate_id' => $result['tax_rate_id'],
-              'name'        => $result['name'],
-              'rate'        => $result['rate'],
-              'type'        => $result['type'],
-              'priority'    => $result['priority']
-            );
+              'name' => $result['name'],
+              'rate' => $result['rate'],
+              'type' => $result['type'],
+              'priority' => $result['priority'],
+            ];
         }
     }
 
-    public function setPaymentAddress($country_id, $zone_id) {
-        $tax_query = $this->db->query("SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = 'payment' AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int)$country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "') ORDER BY tr1.priority ASC");
+    public function setPaymentAddress($country_id, $zone_id)
+    {
+        $tax_query = $this->db->query('SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM ' . DB_PREFIX . 'tax_rule tr1 LEFT JOIN ' . DB_PREFIX . 'tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) INNER JOIN ' . DB_PREFIX . 'tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) LEFT JOIN ' . DB_PREFIX . 'zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) LEFT JOIN ' . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id) WHERE tr1.based = 'payment' AND tr2cg.customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "' AND z2gz.country_id = '" . (int) $country_id . "' AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int) $zone_id . "') ORDER BY tr1.priority ASC");
 
         foreach ($tax_query->rows as $result) {
-            $this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
+            $this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = [
               'tax_rate_id' => $result['tax_rate_id'],
-              'name'        => $result['name'],
-              'rate'        => $result['rate'],
-              'type'        => $result['type'],
-              'priority'    => $result['priority']
-            );
+              'name' => $result['name'],
+              'rate' => $result['rate'],
+              'type' => $result['type'],
+              'priority' => $result['priority'],
+            ];
         }
     }
 
-    public function setStoreAddress($country_id, $zone_id) {
-        $sql = "SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM " . DB_PREFIX . "tax_rule tr1 
-        LEFT JOIN " . DB_PREFIX . "tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) 
-        -- INNER JOIN " . DB_PREFIX . "tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) 
-        LEFT JOIN " . DB_PREFIX . "zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) 
-        LEFT JOIN " . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id)
+    public function setStoreAddress($country_id, $zone_id)
+    {
+        $sql = 'SELECT tr1.tax_class_id, tr2.tax_rate_id, tr2.name, tr2.rate, tr2.type, tr1.priority FROM ' . DB_PREFIX . 'tax_rule tr1 
+        LEFT JOIN ' . DB_PREFIX . 'tax_rate tr2 ON (tr1.tax_rate_id = tr2.tax_rate_id) 
+        -- INNER JOIN ' . DB_PREFIX . 'tax_rate_to_customer_group tr2cg ON (tr2.tax_rate_id = tr2cg.tax_rate_id) 
+        LEFT JOIN ' . DB_PREFIX . 'zone_to_geo_zone z2gz ON (tr2.geo_zone_id = z2gz.geo_zone_id) 
+        LEFT JOIN ' . DB_PREFIX . "geo_zone gz ON (tr2.geo_zone_id = gz.geo_zone_id)
          WHERE tr1.based = 'store' 
-         -- AND tr2cg.customer_group_id = '" . (int)$this->config->get('config_customer_group_id') . "' 
-         AND z2gz.country_id = '" . (int)$country_id . "' 
-         AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int)$zone_id . "')
+         -- AND tr2cg.customer_group_id = '" . (int) $this->config->get('config_customer_group_id') . "' 
+         AND z2gz.country_id = '" . (int) $country_id . "' 
+         AND (z2gz.zone_id = '0' OR z2gz.zone_id = '" . (int) $zone_id . "')
           ORDER BY tr1.priority ASC";
 
         $tax_query = $this->db->query($sql);
 
         foreach ($tax_query->rows as $result) {
-            $this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = array(
+            $this->tax_rates[$result['tax_class_id']][$result['tax_rate_id']] = [
               'tax_rate_id' => $result['tax_rate_id'],
-              'name'        => $result['name'],
-              'rate'        => $result['rate'],
-              'type'        => $result['type'],
-              'priority'    => $result['priority']
-            );
+              'name' => $result['name'],
+              'rate' => $result['rate'],
+              'type' => $result['type'],
+              'priority' => $result['priority'],
+            ];
         }
     }
 
-    public function unsetRates() {
-        $this->tax_rates = array();
+    public function unsetRates()
+    {
+        $this->tax_rates = [];
     }
 
-    public function calculate($value, $tax_class_id, $calculate = true) {
+    public function calculate($value, $tax_class_id, $calculate = true)
+    {
 
         if ($tax_class_id && $calculate) {
             $amount = 0;
@@ -115,8 +123,9 @@ final class Tax {
         }
     }
 
-    public function getRates($value, $tax_class_id) {
-        $tax_rate_data = array();
+    public function getRates($value, $tax_class_id)
+    {
+        $tax_rate_data = [];
 
         if (isset($this->tax_rates[$tax_class_id])) {
 
@@ -133,20 +142,21 @@ final class Tax {
                     $amount += ($value / 100 * $tax_rate['rate']);
                 }
 
-                $tax_rate_data[$tax_rate['tax_rate_id']] = array(
+                $tax_rate_data[$tax_rate['tax_rate_id']] = [
                   'tax_rate_id' => $tax_rate['tax_rate_id'],
-                  'name'        => $tax_rate['name'],
-                  'rate'        => $tax_rate['rate'],
-                  'type'        => $tax_rate['type'],
-                  'amount'      => $amount,
-                );
+                  'name' => $tax_rate['name'],
+                  'rate' => $tax_rate['rate'],
+                  'type' => $tax_rate['type'],
+                  'amount' => $amount,
+                ];
             }
         }
 
         return $tax_rate_data;
     }
 
-    public function getTax($value, $tax_class_id) {
+    public function getTax($value, $tax_class_id)
+    {
         $amount = 0;
 
         $tax_rates = $this->getRates($value, $tax_class_id);
@@ -158,8 +168,9 @@ final class Tax {
         return $amount;
     }
 
-    public function getRateName($tax_rate_id) {
-        $tax_query = $this->db->query("SELECT name FROM " . DB_PREFIX . "tax_rate WHERE tax_rate_id = '" . (int)$tax_rate_id . "'");
+    public function getRateName($tax_rate_id)
+    {
+        $tax_query = $this->db->query('SELECT name FROM ' . DB_PREFIX . "tax_rate WHERE tax_rate_id = '" . (int) $tax_rate_id . "'");
 
         if ($tax_query->num_rows) {
             return $tax_query->row['name'];
@@ -168,11 +179,13 @@ final class Tax {
         }
     }
 
-    public function has($tax_class_id) {
+    public function has($tax_class_id)
+    {
         return isset($this->taxes[$tax_class_id]);
     }
 
-    public function getTaxClasses(){
+    public function getTaxClasses()
+    {
         return $this->tax_rates;
     }
 

--- a/system/library/session/file.php
+++ b/system/library/session/file.php
@@ -2,22 +2,26 @@
 
 namespace Session;
 
-class File extends \SessionHandler {
-
-    public function create_sid() {
+class File extends \SessionHandler
+{
+    public function create_sid(): string
+    {
         return parent::create_sid();
     }
 
-    public function open($path, $name) {
+    public function open(string $path, string $name): bool
+    {
         return true;
     }
 
-    public function close() {
+    public function close(): bool
+    {
         return true;
     }
 
-    public function read($session_id) {
-        $file = session_save_path() . '/sess_' . $session_id;
+    public function read(string $id): string|false
+    {
+        $file = session_save_path() . '/sess_' . $id;
 
         if (is_file($file)) {
             $handle = fopen($file, 'r');
@@ -33,11 +37,12 @@ class File extends \SessionHandler {
             return $data;
         }
 
-        return null;
+        return false;
     }
 
-    public function write($session_id, $data) {
-        $file = session_save_path() . '/sess_' . $session_id;
+    public function write(string $id, string $data): bool
+    {
+        $file = session_save_path() . '/sess_' . $id;
 
         $handle = fopen($file, 'w');
 
@@ -54,16 +59,19 @@ class File extends \SessionHandler {
         return true;
     }
 
-    public function destroy($session_id) {
-        $file = session_save_path() . '/sess_' . $session_id;
+    public function destroy(string $id): bool
+    {
+        $file = session_save_path() . '/sess_' . $id;
 
         if (is_file($file)) {
             unlink($file);
         }
+
+        return true;
     }
 
-    public function gc($maxlifetime) {
-        return parent::gc($maxlifetime);
+    public function gc(int $max_lifetime): int|false
+    {
+        return parent::gc($max_lifetime);
     }
-
 }

--- a/system/loadtime.php
+++ b/system/loadtime.php
@@ -1,25 +1,31 @@
 <?php
-class loadTime{
-    private static $time_start     =   0;
-    private static $time_end       =   0;
-    private static $time           =   0;
 
-    private function __construct() {}
-    public static function start() {
+class loadTime
+{
+    private static $time_start = 0;
+    private static $time_end = 0;
+    private static $time = 0;
+
+    private function __construct()
+    {
+    }
+    public static function start()
+    {
         self::$time_start = microtime(true);
     }
 
-    private static function milliseconds() {
+    private static function milliseconds()
+    {
         //$mt = explode(' ', microtime());
         //return ((int)$mt[1]) * 1000 + ((int)round($mt[0] * 1000));
         return microtime(true);
     }
 
-
-    public static function diff(){
+    public static function diff()
+    {
         self::$time_end = self::milliseconds();
         self::$time = self::$time_end - self::$time_start;
-        return "Loaded in " . self::$time ." seconds\n";
+        return 'Loaded in ' . self::$time ." seconds\n";
     }
 
 }


### PR DESCRIPTION
## Summary

- Add `.gitattributes` enforcing LF line endings for all text files; binary files marked explicitly
- Run `dos2unix` on 40 owned text files (CRLF → LF)
- Add PHP CS Fixer v3 with PSR-12 ruleset (`.php-cs-fixer.php`), apply to 28 recently-touched PHP files
- Add PHPStan level 1 with baseline (`phpstan-baseline.neon`) snapshotting 5432 legacy OpenCart magic-property errors — only new violations will fail
- Fix `Session\File` return type covariance for PHP 8.1+ (`read` returns `string|false`, `destroy` returns `bool`, `gc` returns `int|false`)
- Add `composer require-dev` deps and `cs-fix` / `cs-check` / `analyse` scripts

## Test plan

- [ ] `docker exec -w /app copona-web-1 vendor/bin/phpstan analyse` → `[OK] No errors`
- [ ] `docker exec -w /app copona-web-1 vendor/bin/php-cs-fixer fix --dry-run --diff` → no changes
- [ ] Site loads and admin works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)