### PR TITLE
fix: Bootstrap 5 popover sanitizer, jQuery shims, and cr_translate_mate main lang file

### DIFF
--- a/admin/model/extension/cr_translate_mate.php
+++ b/admin/model/extension/cr_translate_mate.php
@@ -231,11 +231,11 @@ class CrTranslateMateModel extends model
         $count = 0;
         $startHere = !isset($opts['startAfter']) && !$opts['singleFile']; // to indicate where to start loading files
 
-        foreach ($files as $file) {
+        foreach ($files as $fileKey => $file) {
             if ($count >= $opts['length']) {
                 break;
             }
-            $page = $file;
+            $page = $fileKey;
 
             //while ($count < $opts['length'] && list($page, $pageStr) = each($files)) {
             if (!$startHere) { // skip this file if is (or comes before) the file specifed in $opts['startAfter']

--- a/admin/view/javascript/common.js
+++ b/admin/view/javascript/common.js
@@ -174,6 +174,46 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 });
 
+// jQuery shims: re-wire BS3 jQuery plugin calls to native BS5 API.
+// Keeps every template that still calls .tab('show'), .modal('show'), etc. working
+// without needing to edit them one-by-one.
+$.fn.tab = function (action) {
+  return this.each(function () {
+    if (action === 'show') {
+      this.classList.add('nav-link');
+      bootstrap.Tab.getOrCreateInstance(this).show();
+    }
+  });
+};
+
+$.fn.modal = function (options) {
+  return this.each(function () {
+    if (options === 'show') {
+      bootstrap.Modal.getOrCreateInstance(this).show();
+    } else if (options === 'hide') {
+      var m = bootstrap.Modal.getInstance(this);
+      if (m) m.hide();
+    } else if (typeof options === 'object') {
+      bootstrap.Modal.getOrCreateInstance(this, options);
+    }
+  });
+};
+
+$.fn.tooltip = function (options) {
+  return this.each(function () {
+    if (typeof options === 'string') {
+      var t = bootstrap.Tooltip.getInstance(this);
+      if (t) {
+        if (options === 'destroy' || options === 'dispose') t.dispose();
+        else if (options === 'show') t.show();
+        else if (options === 'hide') t.hide();
+      }
+    } else {
+      new bootstrap.Tooltip(this, options || {});
+    }
+  });
+};
+
 $(document).ready(function () {
   //Form Submit for IE Browser
   $('button[type=\'submit\']').on('click', function () {
@@ -294,6 +334,7 @@ $(document).ready(function () {
 
     var popover = new bootstrap.Popover($element[0], {
       html: true,
+      sanitize: false,
       placement: 'right',
       trigger: 'manual',
       content: function () {

--- a/admin/view/template/common/filemanager.tpl
+++ b/admin/view/template/common/filemanager.tpl
@@ -169,15 +169,16 @@
     }, 500);
   });
 
-  $('#button-folder').popover({
+  new bootstrap.Popover(document.getElementById('button-folder'), {
     html: true,
+    sanitize: false,
     placement: 'bottom',
     trigger: 'click',
     title: '<?php echo $entry_folder; ?>',
     content: function () {
-      html = '<div class="input-group">';
+      var html = '<div class="input-group">';
       html += '  <input type="text" name="folder" value="" placeholder="<?php echo $entry_folder; ?>" class="form-control">';
-      html += '  <span class="input-group-btn"><button type="button" title="<?php echo $button_folder; ?>" id="button-create" class="btn btn-primary"><i class="fa fa-plus-circle"></i></button></span>';
+      html += '  <button type="button" title="<?php echo $button_folder; ?>" id="button-create" class="btn btn-primary"><i class="fa fa-plus-circle"></i></button>';
       html += '</div>';
 
       return html;

--- a/admin/view/template/design/media_manager_ajax.tpl
+++ b/admin/view/template/design/media_manager_ajax.tpl
@@ -199,15 +199,16 @@
         }, 500);
     });
 
-    $('#button-folder').popover({
+    new bootstrap.Popover(document.getElementById('button-folder'), {
         html: true,
+        sanitize: false,
         placement: 'bottom',
         trigger: 'click',
         title: '<?php echo $entry_folder; ?>',
         content: function () {
-            html = '<div class="input-group">';
+            var html = '<div class="input-group">';
             html += '  <input type="text" name="folder" value="" placeholder="<?php echo $entry_folder; ?>" class="form-control">';
-            html += '  <span class="input-group-btn"><button type="button" title="<?php echo $button_folder; ?>" id="button-create" class="btn btn-primary"><i class="fa fa-plus-circle"></i></button></span>';
+            html += '  <button type="button" title="<?php echo $button_folder; ?>" id="button-create" class="btn btn-primary"><i class="fa fa-plus-circle"></i></button>';
             html += '</div>';
 
             return html;

--- a/catalog/controller/product/product.php
+++ b/catalog/controller/product/product.php
@@ -310,7 +310,7 @@ class ControllerProductProduct extends Controller {
                 $data['thumb']     = $this->model_tool_image->{$this->config->get('theme_default_product_info_thumb_resize')}($product_info['image'], $this->config->get($this->config->get('config_theme') . '_image_thumb_width'), $this->config->get($this->config->get('config_theme') . '_image_thumb_height'));
                 $data['image_mid'] = $this->model_tool_image->{$this->config->get('theme_default_product_info_image_mid_resize')}($product_info['image'], $this->config->get($this->config->get('config_theme') . '_image_mid_width'), $this->config->get($this->config->get('config_theme') . '_image_mid_height'));
                 $data['image']     = $this->url->getImageUrlOriginal($product_info['image']);
-                $data['popup']     = $this->model_tool_image->{$this->config->get('theme_default_product_info_popup_resize')}($product_info['image'], $this->config->get($this->config->get('config_theme') . '_image_popup_width'), $this->config->get($this->config->get('config_theme') . '_image_popup_height'));
+                $data['popup']     = $this->url->getImageUrlOriginal($product_info['image']);
                 $this->document->addOGMeta('property="og:image"', $data['image_mid']);
                 $this->document->addOGMeta('property="og:image:width"', $this->config->get($this->config->get('config_theme') . '_image_popup_width'));
                 $this->document->addOGMeta('property="og:image:height"', $this->config->get($this->config->get('config_theme') . '_image_popup_height'));
@@ -339,7 +339,7 @@ class ControllerProductProduct extends Controller {
                 }
 
                 $thumb     = $this->model_tool_image->productImage($result['image'], $image_url, $this->config->get($this->config->get('config_theme') . '_image_additional_width'), $this->config->get($this->config->get('config_theme') . '_image_additional_height'), $this->config->get('theme_default_product_info_thumb_resize'));
-                $popup     = $this->model_tool_image->productImage($result['image'], $image_url, $this->config->get($this->config->get('config_theme') . '_image_popup_width'), $this->config->get($this->config->get('config_theme') . '_image_popup_height'), $this->config->get('theme_default_product_info_popup_resize'));
+                $popup     = !empty($result['image']) ? $this->url->getImageUrlOriginal($result['image']) : $image_url;
                 $image_mid = $this->model_tool_image->productImage($result['image'], $image_url, $this->config->get($this->config->get('config_theme') . '_image_mid_width'), $this->config->get($this->config->get('config_theme') . '_image_mid_height'), $this->config->get('theme_default_product_info_image_mid_resize'));
                 $image     = !empty($result['image']) ? $this->url->getImageUrlOriginal($result['image']) : $image_url;
 


### PR DESCRIPTION
## Summary

- **BS5 popover sanitizer** — Bootstrap 5's `DefaultAllowlist` doesn't include `<button>`, so popover content with buttons was silently stripped. Fixed by adding `sanitize: false` to the image thumbnail picker popover (`common.js`) and the folder-create popovers in `filemanager.tpl` / `media_manager_ajax.tpl`. Also converted those two files from the removed jQuery `.popover()` API to `new bootstrap.Popover(el, {...})` and fixed BS3 `input-group-btn` markup.
- **jQuery compatibility shims** (`common.js`) — adds `$.fn.tab`, `$.fn.modal`, and `$.fn.tooltip` that delegate to the native BS5 API. Fixes ~30 admin templates that still call `.tab('show')`, `.modal('show'/'hide')`, `.tooltip('destroy')` etc. without needing individual template edits.
- **cr_translate_mate main language file** (closes #228) — `listFiles()` stores the main lang file as `key='_main_lang_file'` / `value='Main Language File'`. `loadTexts()` was iterating by value, so `$page` got the display string and never matched `singleFile='_main_lang_file'`. Fixed by iterating `foreach ($files as $fileKey => $file)` and using `$page = $fileKey`.
- **Product popup images** — use `getImageUrlOriginal` for lightbox popup images instead of a resized version.

## Test plan

- [ ] Click any image thumbnail in admin product edit — pencil/trash popover should appear with working buttons
- [ ] Open filemanager, click "New Folder" button — folder name popover should appear
- [ ] Tabs in product edit, customer edit, order form should switch correctly (not act as anchor links)
- [ ] Go to Translate Mate → select "Main Language File" from the file dropdown → strings should load
- [ ] Save a translation for a main language file key

🤖 Generated with [Claude Code](https://claude.com/claude-code)