### PR TITLE
Close #209: View on site buttons for information and manufacturer

### DIFF
--- a/admin/controller/catalog/information.php
+++ b/admin/controller/catalog/information.php
@@ -331,8 +331,10 @@ class ControllerCatalogInformation extends Controller {
 
         if (!isset($this->request->get['information_id'])) {
             $data['action'] = $this->url->link('catalog/information/add', 'token=' . $this->session->data['token'] . $url, true);
+            $data['information_id'] = 0;
         } else {
             $data['action'] = $this->url->link('catalog/information/edit', 'token=' . $this->session->data['token'] . '&information_id=' . $this->request->get['information_id'] . $url, true);
+            $data['information_id'] = (int)$this->request->get['information_id'];
         }
 
         $data['cancel'] = $this->url->link('catalog/information', 'token=' . $this->session->data['token'] . $url, true);

--- a/admin/controller/catalog/manufacturer.php
+++ b/admin/controller/catalog/manufacturer.php
@@ -338,8 +338,10 @@ class ControllerCatalogManufacturer extends Controller {
 
         if (!isset($this->request->get['manufacturer_id'])) {
             $data['action'] = $this->url->link('catalog/manufacturer/add', 'token=' . $this->session->data['token'] . $url, true);
+            $data['manufacturer_id'] = 0;
         } else {
             $data['action'] = $this->url->link('catalog/manufacturer/edit', 'token=' . $this->session->data['token'] . '&manufacturer_id=' . $this->request->get['manufacturer_id'] . $url, true);
+            $data['manufacturer_id'] = (int)$this->request->get['manufacturer_id'];
         }
 
         $data['cancel'] = $this->url->link('catalog/manufacturer', 'token=' . $this->session->data['token'] . $url, true);

--- a/admin/view/template/catalog/information_form.tpl
+++ b/admin/view/template/catalog/information_form.tpl
@@ -3,6 +3,9 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
+        <?php if ($information_id) { ?>
+          <a class="btn btn-info" href="<?= HTTP_CATALOG ?>index.php?route=information/information&amp;information_id=<?php echo $information_id; ?>" target="_blank">View page on site</a>
+        <?php } ?>
         <button onclick="saveAndContinue(event);" form="form-information" data-bs-toggle="tooltip" title="<?php echo $button_save_continue; ?>"
                 class="btn btn-primary savecontinue"><i class="fa fa-save"></i><?= $button_save_continue ?></button>
         <button type="submit" form="form-information" data-bs-toggle="tooltip" title="<?php echo $button_save; ?>" class="btn btn-primary"><i class="fa fa-save"></i></button>

--- a/admin/view/template/catalog/manufacturer_form.tpl
+++ b/admin/view/template/catalog/manufacturer_form.tpl
@@ -3,6 +3,9 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="float-end">
+        <?php if ($manufacturer_id) { ?>
+          <a class="btn btn-info" href="<?= HTTP_CATALOG ?>index.php?route=product/manufacturer/info&amp;manufacturer_id=<?php echo $manufacturer_id; ?>" target="_blank">View manufacturer on site</a>
+        <?php } ?>
         <button type="submit" form="form-manufacturer" data-bs-toggle="tooltip" title="<?php echo $button_save; ?>" class="btn btn-primary"><i class="fa fa-save"></i></button>
         <a href="<?php echo $cancel; ?>" data-bs-toggle="tooltip" title="<?php echo $button_cancel; ?>" class="btn btn-secondary"><i class="fa fa-reply"></i></a></div>
       <h1><?php echo $heading_title; ?></h1>


### PR DESCRIPTION
## Summary

- Adds **View page on site** button to the Information edit form → `route=information/information&information_id=X`
- Adds **View manufacturer on site** button to the Manufacturer edit form → `route=product/manufacturer/info&manufacturer_id=X`
- Button only appears when editing an existing record (hidden on Add form, same behaviour as product/category)
- Follows the exact same pattern as the existing buttons in `product_form.tpl` and `category_form.tpl`

Closes #209

## Test plan

- [ ] Edit an existing information page in admin — blue "View page on site" button appears, opens correct frontend URL in new tab
- [ ] Edit an existing manufacturer in admin — blue "View manufacturer on site" button appears, opens correct frontend URL in new tab
- [ ] Click Add (new record) for both — button is absent
- [ ] Existing product and category "View on site" buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)