### PR TITLE
fix: improve cart and guest checkout layout

### DIFF
--- a/catalog/controller/checkout/cart.php
+++ b/catalog/controller/checkout/cart.php
@@ -405,7 +405,7 @@ class ControllerCheckoutCart extends Controller
             // This is Tricky - "too soon" redirect, reason for bugs!
             if (!empty($this->request->post['method']) && $this->request->post['method'] == 'ajax') {
                 $json['status'] = 'OK';
-                $json['current_product_in_cart'] = $this->cart->countProducts((int) $this->request->post['product_id']);
+                $json['current_product_in_cart'] = $this->cart->countProducts((int) ($this->request->post['product_id'] ?? 0));
                 $json['current_cart_total_count'] = $this->cart->countProducts();
                 echo json_encode($json);
                 return false;

--- a/themes/default/assets/js/common.js
+++ b/themes/default/assets/js/common.js
@@ -230,6 +230,9 @@ var cart = {
                 setTimeout(function () {
                     $('#cart').load('index.php?route=common/cart/info');
                     cart.get('#mycart');
+                    if ($('#cart-info').length) {
+                        cart.get('#cart-info');
+                    }
                 }, 100);
                 if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
                     location = 'index.php?route=checkout/cart';
@@ -263,6 +266,9 @@ var cart = {
                     location = 'index.php?route=checkout/cart';
                 } else {
                     $('#cart').load('index.php?route=common/cart/info');
+                    if ($('#cart-info').length) {
+                        cart.get('#cart-info');
+                    }
                 }
             },
             error: function (xhr, ajaxOptions, thrownError) {
@@ -270,16 +276,16 @@ var cart = {
             }
         });
     },
-    'get': function (key) {
+    'get': function (key, callback) {
         $.ajax({
             type: "POST",
             url: 'index.php?route=checkout/cart',
             data: 'checkout=1',
-            success: (function (data) {
+            success: function (data) {
                 $(key).html(data);
-            })
+                if (typeof callback === 'function') callback();
+            }
         });
-
     }
 };
 

--- a/themes/default/template/checkout/cart_info.tpl
+++ b/themes/default/template/checkout/cart_info.tpl
@@ -1,100 +1,99 @@
-<div id="cart-info" class="col-md-12">
-  <form action="<?php echo $action; ?>" method="post" enctype="multipart/form-data" id="cart-contents">
-    <div class="table-responsive">
-      <table class="table">
-        <thead>
-          <tr>
-            <th class="image"><?php echo $column_image; ?></th>
-            <th class="name text-start"><?php echo $column_name; ?></th>
-            <th class="quantity text-start"><?php echo $column_quantity; ?></th>
-            <th class="price text-end"><?php echo $column_price; ?></th>
-            <th class="total text-end"><?php echo $column_total; ?></th>
-          </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($products as $product) { ?>
-              <tr>
-                <td class="image">
-                    <?php if ($product['thumb']) { ?>
-                      <a href="<?php echo $product['href']; ?>"><img src="<?php echo $product['thumb']; ?>" alt="<?php echo $product['name']; ?>" title="<?php echo $product['name']; ?>"  class="img-thumbnail" /></a>
-                  <?php } ?>
-                </td>
+<div class="row gx-4">
+  <div class="col-md-8">
+    <form action="<?php echo $action; ?>" method="post" enctype="multipart/form-data" id="cart-contents">
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="image"><?php echo $column_image; ?></th>
+              <th class="name text-start"><?php echo $column_name; ?></th>
+              <th class="quantity text-start"><?php echo $column_quantity; ?></th>
+              <th class="price text-end"><?php echo $column_price; ?></th>
+              <th class="total text-end"><?php echo $column_total; ?></th>
+            </tr>
+          </thead>
+          <tbody>
+              <?php foreach ($products as $product) { ?>
+                <tr>
+                  <td class="image">
+                      <?php if ($product['thumb']) { ?>
+                        <a href="<?php echo $product['href']; ?>"><img src="<?php echo $product['thumb']; ?>" alt="<?php echo $product['name']; ?>" title="<?php echo $product['name']; ?>" class="img-thumbnail" /></a>
+                    <?php } ?>
+                  </td>
 
-                <td class="name">
-                  <a href="<?php echo $product['href']; ?>"><?php echo $product['name']; ?></a>
-                  <div class="model"><?php echo $column_model; ?>: <?php echo $product['model']; ?></div>
+                  <td class="name">
+                    <a href="<?php echo $product['href']; ?>"><?php echo $product['name']; ?></a>
+                    <div class="model"><?php echo $column_model; ?>: <?php echo $product['model']; ?></div>
 
-                  <?php if (!$product['stock']) { ?>
-                      <span class="text-danger">***</span>
-                  <?php } ?>
+                    <?php if (!$product['stock']) { ?>
+                        <span class="text-danger">***</span>
+                    <?php } ?>
 
-                  <?php if ($product['option']) { ?>
-                      <?php foreach ($product['option'] as $option) { ?>
-                          <br />
-                          <small>- <?php echo $option['name']; ?>: <?php echo $option['value']; ?></small>
-                      <?php } ?>
-                  <?php } ?>
+                    <?php if ($product['option']) { ?>
+                        <?php foreach ($product['option'] as $option) { ?>
+                            <br />
+                            <small>- <?php echo $option['name']; ?>: <?php echo $option['value']; ?></small>
+                        <?php } ?>
+                    <?php } ?>
 
-                  <?php if ($product['reward']) { ?>
-                      <br />
-                      <small><?php echo $product['reward']; ?></small>
-                  <?php } ?>
+                    <?php if ($product['reward']) { ?>
+                        <br />
+                        <small><?php echo $product['reward']; ?></small>
+                    <?php } ?>
 
-                  <?php if ($product['recurring']) { ?>
-                      <br />
-                      <span class="badge bg-info"><?php echo $text_recurring_item; ?></span> <small><?php echo $product['recurring']; ?></small>
-                  <?php } ?>
-                </td>
+                    <?php if ($product['recurring']) { ?>
+                        <br />
+                        <span class="badge bg-info"><?php echo $text_recurring_item; ?></span> <small><?php echo $product['recurring']; ?></small>
+                    <?php } ?>
+                  </td>
 
-                <td class="text-start quantity">
-                  <div class="input-group flex-nowrap" style="min-width:120px;    max-width: 120px;">
-                    <input type="text" name="quantity[<?php echo $product['cart_id']; ?>]" value="<?php echo $product['quantity']; ?>" size="1" class="checkout-quantity form-control" />
-                    <span class="input-group-text">
-                      <span onclick="cart.update(<?php echo $product['cart_id']; ?>, $(this).parent().parent().find('.checkout-quantity').val())" data-bs-toggle="tooltip" title="<?php echo $button_update; ?>" class="btn btn-secondary"><i class="fa fa-refresh"></i></span>
-                      <span type="button" data-bs-toggle="tooltip" title="<?php echo $button_remove; ?>" class="btn btn-secondary" onclick="cart.remove('<?php echo $product['cart_id']; ?>');"><i class="fa fa-times-circle"></i></span>
-                    </span>
-                  </div>
-                </td>
+                  <td class="text-start quantity">
+                    <div class="input-group input-group-sm flex-nowrap" style="width:120px;">
+                      <input type="text" name="quantity[<?php echo $product['cart_id']; ?>]" value="<?php echo $product['quantity']; ?>" class="checkout-quantity form-control" style="min-width:40px;" />
+                      <button type="button" onclick="cart.update(<?php echo $product['cart_id']; ?>, $(this).closest('.input-group').find('.checkout-quantity').val())" data-bs-toggle="tooltip" title="<?php echo $button_update; ?>" class="btn btn-secondary"><i class="fa fa-refresh"></i></button>
+                      <button type="button" data-bs-toggle="tooltip" title="<?php echo $button_remove; ?>" class="btn btn-secondary" onclick="cart.remove('<?php echo $product['cart_id']; ?>');"><i class="fa fa-times-circle"></i></button>
+                    </div>
+                  </td>
 
-                <td class="price"><?php echo $product['price']; ?></td>
+                  <td class="price text-end"><?php echo $product['price']; ?></td>
 
-                <td class="total"><?php echo $product['total']; ?></td>
+                  <td class="total text-end"><?php echo $product['total']; ?></td>
 
-              </tr>
+                </tr>
 
-          <?php } ?>
-
-          <?php foreach ($vouchers as $voucher) { ?>
-              <tr>
-                <td class="image"></td>
-                <td class="name"><?php echo $voucher['description']; ?></td>
-                <td class="quantity">
-                  <div class="input-group flex-nowrap" style="min-width:120px; max-width: 200px;">
-                    <input type="text" name="" value="1" size="1" disabled="disabled" class="form-control" />
-                    <span class="input-group-text"><button type="button" data-bs-toggle="tooltip" title="<?php echo $button_remove; ?>" class="btn btn-secondary" onclick="voucher.remove('<?php echo $voucher['key']; ?>');"><i class="fa fa-times-circle"></i></button></span>
-                  </div>
-                </td>
-                <td class="price"><?php echo $voucher['amount']; ?></td>
-                <td class="total"><?php echo $voucher['amount']; ?></td>
-              </tr>
-          <?php } ?>
-        </tbody>
-      </table>
-    </div>
-  </form>
-</div>
-<div class="row">
-  <div class="col-sm-4 offset-sm-8">
-      <?php if ($modules) { ?>
-        <h2><?php echo $text_next; ?></h2>
-        <p><?php echo $text_next_choice; ?></p>
-        <div class="panel-group" id="accordion">
-            <?php foreach ($modules as $module) { ?>
-                <?php echo $module; ?>
             <?php } ?>
-        </div>
-      <?php } ?>
-    <table class="table table-bordered">
+
+            <?php foreach ($vouchers as $voucher) { ?>
+                <tr>
+                  <td class="image"></td>
+                  <td class="name"><?php echo $voucher['description']; ?></td>
+                  <td class="quantity">
+                    <div class="input-group input-group-sm flex-nowrap" style="width:120px;">
+                      <input type="text" name="" value="1" disabled="disabled" class="form-control" style="min-width:40px;" />
+                      <button type="button" data-bs-toggle="tooltip" title="<?php echo $button_remove; ?>" class="btn btn-secondary" onclick="voucher.remove('<?php echo $voucher['key']; ?>');"><i class="fa fa-times-circle"></i></button>
+                    </div>
+                  </td>
+                  <td class="price text-end"><?php echo $voucher['amount']; ?></td>
+                  <td class="total text-end"><?php echo $voucher['amount']; ?></td>
+                </tr>
+            <?php } ?>
+          </tbody>
+        </table>
+      </div>
+    </form>
+  </div>
+
+  <div class="col-md-4 cart-info-sidebar">
+    <?php if ($modules) { ?>
+      <h5><?php echo $text_next; ?></h5>
+      <p class="text-muted small"><?php echo $text_next_choice; ?></p>
+      <div class="panel-group mb-3" id="accordion">
+          <?php foreach ($modules as $module) { ?>
+              <?php echo $module; ?>
+          <?php } ?>
+      </div>
+    <?php } ?>
+    <table class="table table-bordered table-sm">
         <?php foreach ($totals as $total) { ?>
           <tr>
             <td class="text-end"><strong><?php echo $total['title']; ?>:</strong></td>
@@ -102,9 +101,8 @@
           </tr>
         <?php } ?>
     </table>
+    <div class="cart-info-actions d-flex justify-content-end mt-2">
+      <a href="<?php echo $checkout; ?>" class="btn btn-primary"><?php echo $button_checkout; ?></a>
+    </div>
   </div>
-</div>
-<div class="buttons clearfix">
-  <div class="float-start"><a href="<?php echo $continue; ?>" class="btn btn-secondary"><?php echo $button_shopping; ?></a></div>
-  <div class="float-end"><a href="<?php echo $checkout; ?>" class="btn btn-primary"><?php echo $button_checkout; ?></a></div>
 </div>

--- a/themes/default/template/checkout/guest.tpl
+++ b/themes/default/template/checkout/guest.tpl
@@ -25,12 +25,18 @@
     <?php } ?>
     <div class="row">
         <?php //echo $content_top;?>
-      <div id="content" class="content-cart col-md-12">
+      <div id="content" class="content-cart col-12">
         <div class="onepage-checkout">
+          <!-- Cart contents: full width so the product table has room -->
+          <div class="row mb-3">
+            <div class="col-12">
+              <div id="cart-info"></div>
+            </div>
+          </div>
           <form action="<?php echo $action; ?>" class="form" method="post">
             <div id="step1">
               <div class="row">
-                <div class="col-md-6">
+                <div class="col-md-7">
                   <fieldset>
                     <legend <?= (isset($error_warning['shipping_method']) ? 'class="error"' : ''); ?>><?= $text_shipping_method; ?></legend>
                     <label for="country_id"><?= $entry_country; ?>:</label>
@@ -113,8 +119,7 @@
                     </div>
                   </fieldset>
                 </div>
-                <div class="col-md-6">
-                  <div id="cart-info"></div>
+                <div class="col-md-5">
                   <fieldset>
                     <legend><?= $text_total_title ?>:</legend>
                     <h4><?= $text_price; ?>: <span id="cart_total_value"><?= number_format($cart_total_value, 2); ?> €</span></h4>
@@ -244,12 +249,15 @@
             require_once('checkout.js.tpl'); ?>
         </script>
           <?php echo $content_bottom; ?></div>
-      <?php echo $column_right; ?></div>
+    </div>
   </div>
 </div>
 <script>
 
-    cart.get('#cart-info');
+    cart.get('#cart-info', function() {
+        // Guest page has its own totals + submit — hide the cart sidebar and action button
+        $('#cart-info .cart-info-sidebar, #cart-info .cart-info-actions').hide();
+    });
 
 
 </script>

--- a/themes/default/template/checkout/guest.tpl
+++ b/themes/default/template/checkout/guest.tpl
@@ -255,8 +255,9 @@
 <script>
 
     cart.get('#cart-info', function() {
-        // Guest page has its own totals + submit — hide the cart sidebar and action button
+        // Guest page has its own totals + submit — hide sidebar and expand product table
         $('#cart-info .cart-info-sidebar, #cart-info .cart-info-actions').hide();
+        $('#cart-info .col-md-8').removeClass('col-md-8').addClass('col-12');
     });
 
 


### PR DESCRIPTION
## Summary
- `cart_info.tpl`: two-column layout — product table `col-md-8`, order summary sidebar `col-md-4`
- `cart_info.tpl`: fix quantity input-group (input-group-sm + proper `<button>` elements, not `input-group-text` wrappers)
- `cart_info.tpl`: remove "Continue Shopping" button; add `cart-info-sidebar`/`cart-info-actions` hook classes
- `guest.tpl`: move `#cart-info` to full-width row above the form; split form columns `col-md-7` / `col-md-5`
- `guest.tpl`: hide sidebar + action button after cart load (guest page has its own totals + submit)
- `guest.tpl`: expand product table to `col-12` when sidebar is hidden
- `common.js`: `cart.get()` accepts optional callback; `remove`/`update` refresh `#cart-info` when present
- `cart.php`: fix `Undefined array key 'product_id'` warning in ajax edit handler

## Test plan
- [ ] Add products to cart, visit `/checkout/cart` — table left, summary sidebar right
- [ ] Quantity update and product remove refresh cart in place (no page reload)
- [ ] Visit `/checkout/checkout/guest` — full-width product table, sidebar hidden, form two columns
- [ ] Update/remove from guest page refreshes `#cart-info` correctly
- [ ] No PHP warnings in cart edit ajax response

🤖 Generated with [Claude Code](https://claude.com/claude-code)