### PR TITLE
Pin copona/core to v0.3.0 (Laravel 12 security upgrade)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "php": ">=8.3",
-    "copona/core": "dev-security/upgrade-laravel-12",
+    "copona/core": "^0.3.0",
     "twig/twig": "^3.26"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7525904174b562d60eea0e8ad70efe88",
+    "content-hash": "afa4cbc49bc5e5be7fc8c2e37dcf09f0",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -617,16 +617,16 @@
         },
         {
             "name": "copona/core",
-            "version": "dev-security/upgrade-laravel-12",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/copona/core.git",
-                "reference": "263533c26e70eba01de8bc639e8d411cfc186180"
+                "reference": "baa45d7242a0d4bfd60921b355ab5118ca6cff4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/copona/core/zipball/263533c26e70eba01de8bc639e8d411cfc186180",
-                "reference": "263533c26e70eba01de8bc639e8d411cfc186180",
+                "url": "https://api.github.com/repos/copona/core/zipball/baa45d7242a0d4bfd60921b355ab5118ca6cff4a",
+                "reference": "baa45d7242a0d4bfd60921b355ab5118ca6cff4a",
                 "shasum": ""
             },
             "require": {
@@ -668,10 +668,10 @@
                 "opensource"
             ],
             "support": {
-                "source": "https://github.com/copona/core/tree/security/upgrade-laravel-12",
+                "source": "https://github.com/copona/core/tree/v0.3.0",
                 "issues": "https://github.com/copona/core/issues"
             },
-            "time": "2026-07-24T10:43:33+00:00"
+            "time": "2026-07-24T10:59:13+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -8684,9 +8684,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "copona/core": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary

- `laravel/framework` isn't a direct dependency of this repo — it comes in transitively via `copona/core`, referenced through a VCS repository in `composer.json`. That's why Dependabot flagged the vulnerability here but couldn't auto-fix it: the fix requires editing a different repo's manifest.
- `copona/core` had `laravel/framework` pinned to `^10.48` (10.50.2), the newest available 10.x patch — but Laravel 10 reached end of security support in Feb 2025, so there was no further patch to bump to. The real fix is [copona/core#9](https://github.com/copona/core/pull/9), upgrading to Laravel 12, now merged and tagged as `v0.3.0`.
- This PR switches `composer.json` from `"copona/core": "dev-fix-install-command"` to `"copona/core": "^0.3.0"`, pinning to the tagged release instead of a dev branch (which is safer for a production dependency — dev branches can be rewritten or deleted).

## Test plan

- [x] `composer update copona/core -W` resolves cleanly with `No security vulnerability advisories found.`
- [x] Fresh install (`docker compose up`, `composer install`, `php copona install`) succeeds end-to-end.
- [x] Frontend home page loads (200).
- [x] Category listing renders real products with images and SEO URLs.
- [x] Product detail page loads (200), correct title.
- [x] Admin login (POST) succeeds, redirects to dashboard with valid token.
- [x] Admin dashboard loads authenticated (200).
- [x] No new PHPStan errors introduced by this change (pre-existing, unrelated `pr`/`DB_PREFIX` findings are baseline drift, not caused by this dependency bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)