### PR TITLE
Document cross-repo Laravel dependency and local dev setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,3 +206,97 @@ Admin and catalog share the same PHP session namespace. Both use the `default` c
 - Always branch → PR → merge to master (never direct push to master).
 - Don't commit after each change; batch at end of session.
 - Remote: `git@github.com:copona/copona.git`
+
+---
+
+## Local Dev on a Custom Port (multiple stacks on one host)
+
+If other Docker projects already occupy 8080/3306, don't edit the tracked
+`docker-compose.yml` — add a `docker-compose.override.yml` (gitignored) next
+to it:
+
+```yaml
+services:
+  db:
+    ports:
+      - "3316:3306"
+  web:
+    ports:
+      - "8091:80"
+```
+
+Docker Compose merges override files automatically; no `-f` flag needed.
+Then follow the normal fresh-install procedure — it works unchanged since
+only the *host* port mapping changes, not the container-internal ports.
+
+---
+
+## Automated Testing — There Is None
+
+Neither `copona/copona` nor `copona/core` has a test suite: no PHPUnit/Pest
+config, no `tests/` directory, no CI workflows (`.github/workflows` doesn't
+exist in either repo). The only checks are static analysis via Composer
+scripts in `copona/copona`'s `composer.json`:
+
+```bash
+composer analyse   # phpstan
+composer cs-check   # php-cs-fixer --dry-run
+composer cs-fix      # php-cs-fixer fix
+```
+
+`phpstan.neon` / the baseline currently has pre-existing unrelated findings
+(`pr` function not found in a few catalog controllers, a `DB_PREFIX`
+constant baseline count mismatch) — these are static-analysis artifacts of
+globals/constants defined at runtime bootstrap, not real bugs, and predate
+any dependency work. Don't treat them as regressions from unrelated changes.
+
+For actual verification, there's no substitute for booting the stack and
+smoke-testing: frontend home, a category listing (confirms DB reads +
+`productImage()`), a product detail page (SEO routing), and an admin
+login → dashboard round trip (confirms session/auth + DB writes).
+
+---
+
+## laravel/framework Is Not a Direct Dependency — It's Transitive via copona/core
+
+`copona/copona`'s `composer.json` does **not** require `laravel/framework`
+directly. It requires `copona/core` via a VCS repository:
+
+```json
+"repositories": {
+  "copona-core": { "type": "vcs", "url": "git@github.com:copona/core.git" }
+},
+"require": { "copona/core": "^0.3.0" }
+```
+
+`copona/core` is where `laravel/framework` actually lives (used for the
+`Illuminate\Database` Capsule/Eloquent adapter — see
+`src/Database/Adapters/Eloquent.php` and `src/Database/OrmModel.php`, the
+*only* two files in that package touching the `Illuminate` namespace).
+
+**Why Dependabot can't auto-fix Laravel advisories in this repo**: the
+version constraint Dependabot would need to edit lives in a different
+repo's `composer.json`. GitHub's dependency graph still flags the
+vulnerable version here (because `composer.lock` records it), but there's
+no manifest in *this* repo for a bot to patch. The fix always has to be a
+manual PR against `copona/core`, followed by a version bump here.
+
+**Laravel version history in copona/core** (`composer.json` → `require` →
+`laravel/framework`): 5.6 → 5.8 → 6.20 → 9.0 → 10.48 (CVE-2025-27515) →
+12.0 (2026-07, Laravel 10 hit EOL for security support Feb 2025 with
+10.50.2 already the newest 10.x patch — no further 10.x fix existed, so
+the only real remediation was a major-version jump).
+
+**When bumping laravel/framework in copona/core again**, watch for:
+- `phpfastcache/phpfastcache` — 8.x pins `psr/simple-cache ~1.0`, which
+  conflicts with `robmorgan/phinx`'s `cakephp/datasource` (`^2.0||^3.0`).
+  Needs `phpfastcache` `^9.0`+ alongside any Laravel version requiring
+  newer `symfony/console`.
+- `symfony/finder`, `symfony/console`, `symfony/css-selector` are also
+  required directly by `copona/core` (not just pulled in via Laravel) —
+  their constraint has to be widened to match whatever `symfony/console`
+  version the new Laravel release requires.
+- Prefer pinning `copona/copona`'s `composer.json` to a tagged `copona/core`
+  release (e.g. `^0.3.0`) rather than `dev-<branch>` — dev-branch refs can
+  be deleted or rewritten after merge, and there's no reason to stay on one
+  once the branch's PR has landed and been tagged.

--- a/README.md
+++ b/README.md
@@ -35,19 +35,20 @@ Copona is in development mode — please use it, test it, and post issues, bugs,
 * Prepared environment
     * With Docker
         * Install [Docker](https://docs.docker.com/engine/installation/) and [Docker Compose](https://docs.docker.com/compose/install/)
-        * Duplicate `.env.example` to `.env` and configure the file
-        * Execute `docker-compose up -d`
-        * Access bash via `docker-compose exec web bash` and execute:
-            * `cd /app && composer install`
-            * `cd /app && php vendor/bin/phinx migrate`
+        * Do **not** create `.env` by hand — the installer generates it, and its own "is this installed?" check just looks for `.env`, so a pre-existing one makes it skip setup and leave the database empty.
+        * Execute `docker compose up -d --build`
+        * Wait for MariaDB to finish starting (a few seconds), then run:
+            * `docker exec -w /app <web-container> composer install --no-interaction`
+            * `docker exec -u application <web-container> php /app/copona install --no-interaction`
+        * The install command reads its DB/admin settings from the environment variables already set in `docker-compose.yml` (`DB_DRIVER`, `DB_HOSTNAME`, `DB_DATABASE`, `ADMIN_USERNAME`, etc.) and creates `.env`, the database schema, and runs migrations for you.
     * Manual install
         * Install a web server: Apache, IIS, etc.
         * Install PHP and MySQL
         * Install Composer [https://getcomposer.org/](https://getcomposer.org/)
         * From the command prompt, execute:
             * `composer install`
+            * `php copona install` (interactive) — asks for DB/admin details, creates `.env`, and runs migrations
 * Navigate to your web address: `http://domain-OR-IPaddress/` or `http://domain-OR-IPaddress/subfolder-where-you-cloned`
-* Execute migration: `php vendor/bin/phinx migrate`
 * If all requirements have been met, fill in the form and enjoy!
 
 ## Update


### PR DESCRIPTION
## Summary

Follow-up to #288 (merged before this commit landed on the branch).
Adds CLAUDE.md documentation covering:

- Why Dependabot can't auto-fix Laravel advisories here (transitive via `copona/core`, a VCS-referenced repo — the constraint Dependabot would need to edit lives in a different repo's manifest).
- Laravel version history in `copona/core` and known dependency conflicts to watch for on the next bump (phpfastcache/psr-simple-cache, symfony/console).
- Neither repo has an automated test suite (no PHPUnit/Pest, no CI workflows) — only phpstan/php-cs-fixer via composer scripts.
- The `docker-compose.override.yml` pattern for running on a custom port alongside other local Docker stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)